### PR TITLE
Refactor traversal to segmented directory store

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,7 @@ pub fn build(b: *std.Build) void {
         // Later on we'll use this module as the root module of a test executable
         // which requires us to specify a target.
         .target = target,
+        .link_libc = true,
     });
 
     // Here we define an executable. An executable needs to have a root module
@@ -80,6 +81,7 @@ pub fn build(b: *std.Build) void {
                 // importing modules from different packages).
                 .{ .name = "wtfs", .module = mod },
             },
+            .link_libc = true,
         }),
     });
 


### PR DESCRIPTION
## Summary
- replace the multi-array queue with a segmented list of `DirectoryNode` entries that retain basenames and open directory handles while scans run
- introduce a shared task queue with persistent workers that pull directory indices, spawn children, and record traversal totals before aggregating results
- close directory handles and free stored names prior to emitting the summary and ensure the build links against libc for the macOS scanner

## Testing
- `zig build` *(fails: undefined symbol getattrlistbulk on this Linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd766b98f4832c9c0d9884621bb79d