### PR TITLE
Fix Linux fallback scanner and guard macOS policy

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -425,11 +425,13 @@ pub fn main() !void {
     defer idxset.deinit(allocator);
 
     // forbid on-demand file content loading; don't pull in data from iCloud
-    switch (wtfs.setiopolicy_np(.vfs_materialize_dataless_files, .process, 1)) {
-        0 => {},
-        else => |rc| {
-            std.debug.panic("setiopolicy_np: {t}", .{std.posix.errno(rc)});
-        },
+    if (builtin.target.os.tag == .macos) {
+        switch (wtfs.setiopolicy_np(.vfs_materialize_dataless_files, .process, 1)) {
+            0 => {},
+            else => |rc| {
+                std.debug.panic("setiopolicy_np: {t}", .{std.posix.errno(rc)});
+            },
+        }
     }
 
     var progress_root = std.Progress.start(.{ .root_name = "Scanning" });


### PR DESCRIPTION
## Summary
- implement a portable fallback DirScanner that reuses the attribute masks, copies entry names, and queries stat data when needed
- guard the macOS-specific setiopolicy_np call so the tool links successfully on other platforms

## Testing
- zig build

------
https://chatgpt.com/codex/tasks/task_e_68ce13b4b3a8832cacf16bfece9dd305