### PR TITLE
Add large file tracking to disk scan

### DIFF
--- a/src/Worker.zig
+++ b/src/Worker.zig
@@ -305,6 +305,10 @@ fn processEntry(
             metrics.total_size += file.allocsize;
             metrics.total_files += 1;
             batch_metrics.batch_files += 1;
+
+            if (file.allocsize >= self.ctx.large_file_threshold) {
+                try self.ctx.recordLargeFileLocked(index, name, file.allocsize);
+            }
         },
         .symlink => batch_metrics.batch_symlinks += 1,
         .other => batch_metrics.batch_other += 1,


### PR DESCRIPTION
## Summary
- capture large-file metadata alongside directory bookkeeping so workers can report notable files
- include a large-file section in the disk scan summary using the configurable threshold
- add a --large-file-threshold CLI flag (default 100MiB) for tuning which files are tracked

## Testing
- zig build test

------
https://chatgpt.com/codex/tasks/task_e_68ce6d038790832ca84caf42c808bcb5