### PR TITLE
Add streaming scanner output support

### DIFF
--- a/src/Worker.zig
+++ b/src/Worker.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Context = @import("Context.zig");
 const wtfs = @import("wtfs").mac;
+const is_macos = builtin.target.os.tag == .macos;
 
 const Worker = @This();
 
@@ -82,12 +84,12 @@ pub fn directoryWorker(ctx: *Context) void {
     };
     defer worker.path_buffer.deinit(worker.allocator);
     defer worker.marquee.end();
-    
+
     worker.progress_writer = std.Io.Writer.fixed(&worker.progress_buffer);
 
     while (worker.ctx.task_queue.pop()) |index| {
         worker.processTask(index);
-        
+
         // Mark task complete and check if we're done
         if (worker.ctx.outstanding.fetchSub(1, .acq_rel) == 1) {
             worker.ctx.task_queue.close();
@@ -97,7 +99,7 @@ pub fn directoryWorker(ctx: *Context) void {
 
 fn processTask(self: *Worker, index: usize) void {
     self.updateProgressDisplay(index);
-    
+
     _ = self.processDirectory(index) catch |err| {
         std.debug.panic("error {t}", .{err});
     };
@@ -106,10 +108,10 @@ fn processTask(self: *Worker, index: usize) void {
 fn updateProgressDisplay(self: *Worker, index: usize) void {
     if (@mod(self.items_processed, 100) == 0) {
         const basename = self.extractName(self.ctx.getNode(index).basename);
-        
+
         const dt_ns = self.timer.lap();
         const speed = self.items_processed * 1_000_000_000 / @max(dt_ns, 1);
-        
+
         self.progress_writer.print("{d: >5} Hz  {s}", .{ speed, basename }) catch unreachable;
         self.marquee.setName(self.progress_writer.buffered());
         self.progress_writer.end = 0;
@@ -141,13 +143,13 @@ fn processDirectory(self: *Worker, index: usize) !usize {
 
     const dir_fd = try self.openDirectory(index);
     if (dir_fd == Context.invalid_fd) return 0; // Directory was inaccessible
-    
+
     var metrics = ScanMetrics{};
     try self.scanDirectory(index, dir_fd, &metrics);
-    
+
     // Store the totals for this directory
     self.ctx.setTotals(index, metrics.total_size, metrics.total_files);
-    
+
     return metrics.total_size;
 }
 
@@ -156,7 +158,7 @@ fn processDirectory(self: *Worker, index: usize) !usize {
 fn openDirectory(self: *Worker, index: usize) !std.posix.fd_t {
     const node = self.ctx.getNode(index);
     const basename = self.extractName(node.basename);
-    
+
     if (index != 0) {
         return try self.openChildDirectory(index, node, basename);
     } else {
@@ -172,13 +174,13 @@ fn openChildDirectory(
 ) !std.posix.fd_t {
     const parent_index: usize = @intCast(node.parent);
     const parent = self.ctx.getNode(parent_index);
-    
+
     // Try to open the subdirectory using parent's fd
     const opened = wtfs.openSubdirectory(parent.fd, basename);
-    
+
     // We've successfully used the parent fd for openat(), release our reference
     self.ctx.releaseParentFdAfterOpen(parent_index);
-    
+
     if (opened) |fd| {
         self.ctx.setDirectoryFd(index, fd);
         return fd;
@@ -210,16 +212,15 @@ fn openRootDirectory(
             return err;
         },
     };
-    
+
     // Close old fd if present
     if (node.fd != Context.invalid_fd) {
         std.posix.close(node.fd);
     }
-    
+
     self.ctx.setDirectoryFd(index, opened);
     return opened;
 }
-
 
 // ===== Directory Scanning =====
 
@@ -230,19 +231,60 @@ fn scanDirectory(
     metrics: *ScanMetrics,
 ) !void {
     var scanner = Scanner.init(dir_fd, &self.scan_buffer);
-    
+    var wrote_context = false;
+
     // Keep this directory's fd open while we scan (in case we find subdirectories)
     self.ctx.retainParentFd(index);
     defer self.ctx.releaseParentFd(index);
-    
+
     while (true) {
         const has_batch = scanner.fill() catch |err| {
             return self.handleScanError(index, err);
         };
         if (!has_batch) break;
-        
+
+        if (self.ctx.stream_out) |out| {
+            try self.writeStreamBatch(index, &scanner, &wrote_context, out);
+        }
+
         try self.processBatch(index, &scanner, metrics);
+
+        scanner.resetAfterBatch();
     }
+}
+
+fn writeStreamBatch(
+    self: *Worker,
+    index: usize,
+    scanner: *Scanner,
+    wrote_context: *bool,
+    out: *std.Io.Writer,
+) !void {
+    if (!is_macos) return;
+
+    const payload = scanner.rawBatchSlice();
+    if (payload.len == 0) return;
+
+    self.ctx.stream_mutex.lock();
+    defer self.ctx.stream_mutex.unlock();
+
+    if (!wrote_context.*) {
+        const node = self.ctx.getNode(index);
+        const ctx_record = wtfs.stream.DirContext{
+            .dir_ix = @intCast(index),
+            .parent = @intCast(node.parent),
+            .baseix = node.basename,
+            .flags = scanner.streamFlags(),
+        };
+        try wtfs.stream.writeDirContext(out, ctx_record);
+        wrote_context.* = true;
+    }
+
+    var batch_header = wtfs.stream.RawBatch{
+        .len = @intCast(payload.len),
+    };
+    try out.writeAll(std.mem.asBytes(&batch_header));
+    try out.writeAll(payload);
 }
 
 fn processBatch(
@@ -254,26 +296,26 @@ fn processBatch(
     self.ctx.directories_mutex.lock();
     var lock_released = false;
     defer if (!lock_released) self.ctx.directories_mutex.unlock();
-    
+
     var batch_entries: usize = 0;
     var batch_metrics = ScanMetrics{};
-    
+
     while (true) {
         const maybe_entry = scanner.next() catch |err| {
             self.ctx.directories_mutex.unlock();
             lock_released = true;
             return self.handleScanError(index, err);
         };
-        
+
         const entry = maybe_entry orelse break;
         batch_entries += 1;
-        
+
         try self.processEntry(index, entry, metrics, &batch_metrics);
     }
-    
+
     self.ctx.directories_mutex.unlock();
     lock_released = true;
-    
+
     self.updateStatistics(batch_entries, &batch_metrics);
 }
 
@@ -285,11 +327,11 @@ fn processEntry(
     batch_metrics: *ScanMetrics,
 ) !void {
     const name = std.mem.sliceTo(entry.name, 0);
-    
+
     // Skip empty, current, and parent directory entries
     if (name.len == 0) return;
     if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) return;
-    
+
     switch (entry.kind) {
         .dir => {
             if (self.ctx.skip_hidden and name[0] == '.') return;
@@ -353,7 +395,7 @@ fn handleScanError(
 ) !void {
     _ = self.ctx.stats.scanner_errors.fetchAdd(1, .monotonic);
     self.errprogress.completeOne();
-    
+
     if (err == error.DeadLock) {
         self.errprogress.setName("dataless file");
         _ = self.ctx.stats.inaccessible_dirs.fetchAdd(1, .monotonic);

--- a/src/scanner_stream.zig
+++ b/src/scanner_stream.zig
@@ -1,0 +1,231 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.target.os.tag != .macos) {
+        @compileError("scanner_stream is only supported on macOS");
+    }
+}
+
+const mac = @import("wtfs").mac;
+
+const posix = std.posix;
+
+pub const DirContext = packed struct {
+    tag: u8 = 1,
+    ver: u8 = 0,
+    _pad: u16 = 0,
+    dir_ix: u64,
+    parent: u64,
+    baseix: u32,
+    flags: u32,
+};
+
+pub const RawBatch = packed struct {
+    tag: u8 = 2,
+    ver: u8 = 0,
+    _pad: u16 = 0,
+    len: u32,
+};
+
+pub const AttrBulkReader = struct {
+    interface: std.Io.Reader,
+    state: State,
+
+    const State = struct {
+        fd: std.posix.fd_t,
+        mask: mac.AttrGroupMask,
+        options: mac.FsOptMask,
+        last_entries: usize = 0,
+        last_bytes: usize = 0,
+        last_error: ?anyerror = null,
+    };
+
+    pub fn init(
+        dirfd: std.posix.fd_t,
+        mask: mac.AttrGroupMask,
+        buffer: []u8,
+    ) AttrBulkReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = stream },
+                .buffer = buffer,
+                .seek = 0,
+                .end = 0,
+            },
+            .state = .{
+                .fd = dirfd,
+                .mask = mask,
+                .options = .{
+                    .nofollow = true,
+                    .report_fullsize = true,
+                    .pack_invalid_attrs = true,
+                },
+            },
+        };
+    }
+
+    pub fn fillBatch(self: *AttrBulkReader) !bool {
+        self.interface.seek = 0;
+        self.interface.end = 0;
+        self.state.last_entries = 0;
+        self.state.last_bytes = 0;
+        self.state.last_error = null;
+
+        while (true) {
+            self.interface.fillMore() catch |err| switch (err) {
+                error.EndOfStream => return false,
+                error.ReadFailed => {
+                    const stored = self.state.last_error orelse return error.ReadFailed;
+                    self.state.last_error = null;
+                    return stored;
+                },
+            };
+
+            if (self.state.last_bytes != 0) {
+                self.interface.seek = 0;
+                return true;
+            }
+        }
+    }
+
+    pub fn lastEntryCount(self: *const AttrBulkReader) usize {
+        return self.state.last_entries;
+    }
+
+    pub fn lastBatchBytes(self: *const AttrBulkReader) usize {
+        return self.state.last_bytes;
+    }
+
+    pub fn batchSlice(self: *const AttrBulkReader) []const u8 {
+        return self.interface.buffer[0..self.state.last_bytes];
+    }
+
+    pub fn resetBuffer(self: *AttrBulkReader) void {
+        self.interface.seek = 0;
+        self.interface.end = 0;
+        self.state.last_entries = 0;
+        self.state.last_bytes = 0;
+        self.state.last_error = null;
+    }
+
+    pub fn flags(self: *const AttrBulkReader) u32 {
+        return @bitCast(self.state.options);
+    }
+};
+
+pub fn makeAttrBulkReader(
+    dirfd: std.posix.fd_t,
+    mask: mac.AttrGroupMask,
+    buffer: []u8,
+) AttrBulkReader {
+    return AttrBulkReader.init(dirfd, mask, buffer);
+}
+
+pub fn writeDirContext(w: *std.Io.Writer, ctx: DirContext) !void {
+    try w.writeAll(std.mem.asBytes(&ctx));
+}
+
+fn stream(
+    io_reader: *std.Io.Reader,
+    io_writer: *std.Io.Writer,
+    limit: std.Io.Limit,
+) std.Io.Reader.StreamError!usize {
+    const reader: *AttrBulkReader = @alignCast(@fieldParentPtr("interface", io_reader));
+
+    const dest = limit.slice(try io_writer.writableSliceGreedy(1));
+    if (dest.len != 0) {
+        const written = try reader.performRead(dest);
+        io_writer.advance(written);
+        return written;
+    }
+
+    const buffer_tail = io_reader.buffer[io_reader.end..];
+    if (buffer_tail.len == 0) return 0;
+
+    const written = reader.performRead(buffer_tail) catch |err| switch (err) {
+        error.EndOfStream => return error.EndOfStream,
+        error.ReadFailed => return error.ReadFailed,
+    };
+    io_reader.end += written;
+    return 0;
+}
+
+fn performRead(
+    self: *AttrBulkReader,
+    dest: []u8,
+) std.Io.Reader.StreamError!usize {
+    var al = mac.AttrList{
+        .bitmapcount = mac.ATTR_BIT_MAP_COUNT,
+        .reserved = 0,
+        .attrs = self.state.mask,
+    };
+
+    const rc = mac.getattrlistbulk(self.state.fd, &al, dest.ptr, dest.len, self.state.options);
+    if (rc < 0) {
+        return self.handleError(rc);
+    }
+
+    if (rc == 0) {
+        self.state.last_entries = 0;
+        self.state.last_bytes = 0;
+        return error.EndOfStream;
+    }
+
+    const positive = std.math.absInt(@as(i64, rc)) catch return self.fail(error.ReadFailed);
+    const entry_count = std.math.cast(usize, positive) orelse return self.fail(error.ReadFailed);
+    const byte_len = computeBatchBytes(dest, entry_count) catch {
+        self.state.last_entries = 0;
+        self.state.last_bytes = 0;
+        return self.fail(error.ReadFailed);
+    };
+
+    self.state.last_entries = entry_count;
+    self.state.last_bytes = byte_len;
+    self.state.last_error = null;
+    return byte_len;
+}
+
+fn handleError(self: *AttrBulkReader, rc: anytype) std.Io.Reader.StreamError!usize {
+    const err = posix.errno(rc);
+    switch (err) {
+        .INTR, .AGAIN => {
+            self.state.last_entries = 0;
+            self.state.last_bytes = 0;
+            return 0;
+        },
+        .NOENT => unreachable,
+        .NOTDIR => return self.fail(error.NotDir),
+        .BADF => return self.fail(error.BadFileDescriptor),
+        .ACCES => return self.fail(error.PermissionDenied),
+        .FAULT => return self.fail(error.BadAddress),
+        .RANGE => return self.fail(error.BufferTooSmall),
+        .INVAL => return self.fail(error.InvalidArgument),
+        .IO => return self.fail(error.ReadFailed),
+        .TIMEDOUT => return self.fail(error.TimedOut),
+        .DEADLK => return self.fail(error.DeadLock),
+        else => |unexpected| {
+            std.debug.panic("unexpected errno {s}", .{@tagName(unexpected)});
+        },
+    }
+}
+
+fn fail(self: *AttrBulkReader, err: anyerror) std.Io.Reader.StreamError!usize {
+    self.state.last_entries = 0;
+    self.state.last_bytes = 0;
+    self.state.last_error = err;
+    return error.ReadFailed;
+}
+
+fn computeBatchBytes(dest: []const u8, entry_count: usize) error{ReadFailed}!usize {
+    var offset: usize = 0;
+    var remaining = entry_count;
+    while (remaining != 0) : (remaining -= 1) {
+        if (offset + @sizeOf(u32) > dest.len) return error.ReadFailed;
+        const reclen = std.mem.readIntLittle(u32, dest[offset .. offset + @sizeOf(u32)]);
+        const len = std.math.cast(usize, reclen) orelse return error.ReadFailed;
+        offset += len;
+        if (offset > dest.len) return error.ReadFailed;
+    }
+    return offset;
+}


### PR DESCRIPTION
## Summary
- add a macOS-only streaming Reader module that exposes DirContext and RawBatch records
- integrate the Reader into the mac scanner, worker, and context so raw batches can be serialized alongside traversal
- expose a CLI entry point and runStream helper that writes the streaming output when --stream-output is requested

## Testing
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_68ced6a9edcc832cb3899bd7cf51b202