### PR TITLE
Add trace summary command and update io_uring trace reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ Output:
 * src                               x96
 ```
 
+## io_uring trace summaries
+
+When running on Linux with `--trace-uring` enabled, wtfs writes a binary log of
+io_uring activity. You can generate a human-readable summary of this trace with
+the `trace-summary` subcommand:
+
+```bash
+./zig-out/bin/wtfs trace-summary wtfs-uring.log
+```
+
+The summary groups completions, fallbacks, queue drain activity, and cache hits,
+making it easier to understand io_uring behaviour during a scan.
+
 ## License
 
 MIT License - See [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add a `trace-summary` subcommand to print io_uring trace statistics from the new binary logs
- refresh the trace reader implementation to work with the current stdlib APIs and reuse shared table utilities
- document how to summarize traces in the README

## Testing
- TERM=dumb zig build
- TERM=dumb zig build test

------
https://chatgpt.com/codex/tasks/task_e_68cf8ab76c04832c8dd30636eff9d0bd