### PR TITLE
Port scanner to Zig 0.17 and add TUI deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .zig-cache
 zig-out
 *.log
+.DS_Store
 
 # Nix outputs
 result
@@ -19,3 +20,4 @@ wtfs/_bin/
 *.bin
 *.wtfs
 test_*.py
+!tests/test_*.py

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ uv run wtfs-tui scan.bin
 - `Tab` - Switch between Directories and Large Files tabs
 - `q` - Quit
 - `Ctrl+P` - Command palette
+- `m` - Mark or unmark the selected directory for deletion
+- `d` - Review and permanently delete marked directories
+
+Deletion is enabled automatically after a fresh scan. When opening a saved
+dump directly, provide its original scan root:
+
+```bash
+uv run wtfs-tui scan.bin --root /path/that/was/scanned
+```
 
 The interactive mode makes it easy to explore large directory structures and quickly find what's taking up space!
 

--- a/build.zig
+++ b/build.zig
@@ -23,16 +23,14 @@ pub fn build(b: *std.Build) !void {
     });
 
     const run_cmd = b.addRunArtifact(exe_wtfscan);
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
+    run_cmd.addPassthruArgs();
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
     const run_dumpstruct = b.addRunArtifact(exe_wtfscan);
     run_dumpstruct.addArg("--dump-structs");
-    const structfile = run_dumpstruct.captureStdOut();
+    const structfile = run_dumpstruct.captureStdOut(.{});
     const install_structfile = b.addInstallFile(structfile, "wtfstructs.txt");
 
     b.getInstallStep().dependOn(&install_structfile.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x7eff6b1257c6afa0, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.17.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/src/CapacityLatch.zig
+++ b/src/CapacityLatch.zig
@@ -11,14 +11,14 @@
 ///
 /// Growth path (rare):
 ///  - Call `acquireOrWaitFor(target_cap)`:
-///     * returns **Growth** (mutex held) if work is needed — you initialize backing
+///     * returns **Growth** (growth lock held) if work is needed — you initialize backing
 ///       storage up to `target_cap`, then `publishTo(target_cap)` (release) and unlock
 ///     * returns **null** if another thread already brought `cap` to `target_cap`
-///       (this function waited on a condvar if necessary)
+///       (no wait is needed: the check happens under the growth lock)
 
 // Memory ordering (why it’s correct):
 //  - Writers grow: **initialize memory first**, then `publishTo()` does a **release**
-//    store to `cap` and wakes waiters. This guarantees visibility of all initialized
+//    store to `cap`. This guarantees visibility of all initialized
 //    bytes to threads that subsequently **acquire**-load `cap` (via `snapshot()`).
 //  - Appenders: `Reservation.take()` CASes `len` with **acq_rel**, which linearizes
 //    append; the **acquire** in readers’ `snapshot()` must precede any deref into
@@ -35,9 +35,28 @@ len: std.atomic.Value(usize) = .init(0),
 /// Logical rows published/initialized (upper bound safe for readers).
 cap: std.atomic.Value(usize) = .init(0),
 
-/// Serialized growth; waiters sleep here until `_cap` advances.
-mu: std.Thread.Mutex = .{},
-cv: std.Thread.Condition = .{},
+/// Serialized growth. A spin lock rather than a blocking mutex: blocking
+/// primitives now need an `Io` instance, and threading one through every
+/// container API would be a lot of plumbing for a lock that is taken O(log n)
+/// times per scan and held only for a single shelf allocation.
+growing: std.atomic.Value(bool) = .init(false),
+
+fn lockGrowth(self: *CapacityLatch) void {
+    var spins: usize = 0;
+    while (self.growing.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+        spins += 1;
+        if (spins < 64) {
+            std.atomic.spinLoopHint();
+        } else {
+            spins = 0;
+            std.Thread.yield() catch std.atomic.spinLoopHint();
+        }
+    }
+}
+
+fn unlockGrowth(self: *CapacityLatch) void {
+    self.growing.store(false, .release);
+}
 
 /// Snapshot of `{ len, cap }` with **acquire** semantics on both.
 ///
@@ -105,7 +124,7 @@ pub fn reservation(self: *CapacityLatch, count: usize) error{Overflow}!Reservati
     return .{ .latch = self, .base = base, .len = len };
 }
 
-/// Growth guard: owning the mutex while preparing capacity.
+/// Growth guard: owning the growth lock while preparing capacity.
 ///
 /// Invariants while held:
 ///  - Caller must initialize all storage for rows in `[start_cap .. target_cap)`
@@ -115,8 +134,8 @@ pub const Growth = struct {
     start_cap: usize,
     held: bool = true,
 
-    /// Publish all rows up to `target_cap` (exclusive upper bound), with **release**,
-    /// then wake all waiters. This is the *only* place `_cap` advances.
+    /// Publish all rows up to `target_cap` (exclusive upper bound), with **release**.
+    /// This is the *only* place `_cap` advances.
     ///
     /// Precondition: the caller has fully initialized every byte required
     /// for rows `[start_cap .. target_cap)`.
@@ -126,20 +145,18 @@ pub const Growth = struct {
     /// will also observe the initialization that happened-before this call.
     pub fn publishTo(self: *Growth, target_cap: usize) void {
         self.l.cap.store(target_cap, .release);
-        // Wake all waiters; Condition requires holding the mutex.
-        self.l.cv.broadcast();
     }
 
-    /// Release the growth mutex. Prefer `defer g.unlock()`.
+    /// Release the growth lock. Prefer `defer g.unlock()`.
     pub fn unlock(self: *Growth) void {
         if (!self.held) return;
-        self.l.mu.unlock();
+        self.l.unlockGrowth();
         self.held = false;
     }
 };
 
 /// Ensure `cap >= target_cap`: either become the grower (return a Growth guard
-/// with the mutex held) or, if another thread can/does grow, wait until the
+/// with the growth lock held) or, if another thread can/does grow, wait until the
 /// condition is satisfied and return `null`.
 ///
 /// Typical usage in your container:
@@ -152,17 +169,16 @@ pub const Growth = struct {
 ///   } // else: target already satisfied (this waited if needed)
 /// ```
 pub fn acquireOrWaitFor(self: *CapacityLatch, target_cap: usize) ?Growth {
-    self.mu.lock();
+    self.lockGrowth();
 
     // Fast path: nothing to do (also covers spurious wakeups in callers).
     const now = self.cap.load(.acquire);
     if (now >= target_cap) {
-        self.mu.unlock();
+        self.unlockGrowth();
         return null;
     }
 
-    // Policy: caller grows immediately (holds the mutex).
-    // If you prefer to *always* wait instead, replace this with a loop on _cv.wait.
+    // Policy: caller grows immediately (holds the lock).
     return .{ .l = self, .start_cap = now };
 }
 

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -29,8 +29,9 @@ pub const invalid_fd: std.posix.fd_t = -1;
 const Context = @This();
 
 allocator: std.mem.Allocator,
+io: std.Io,
 
-directories_mutex: std.Thread.Mutex = .{},
+directories_mutex: std.Io.Mutex = .init,
 directories: *DirectoryTable,
 
 large_files: *std.MultiArrayList(LargeFile),
@@ -40,8 +41,7 @@ outstanding: AtomicUsize = AtomicUsize.init(0),
 
 names_buffer: *SegmentedStringBuffer,
 
-pool: *std.Thread.Pool,
-wait_group: *std.Thread.WaitGroup,
+worker_group: *std.Io.Group,
 
 progress_node: std.Progress.Node,
 errprogress: std.Progress.Node,
@@ -67,36 +67,36 @@ pub fn directoryCString(self: *const Context, index: usize) [:0]const u8 {
 }
 
 pub fn setTotals(self: *Context, index: usize, size: u64, files: usize) void {
-    self.directories_mutex.lock();
-    defer self.directories_mutex.unlock();
+    self.directories_mutex.lockUncancelable(self.io);
+    defer self.directories_mutex.unlock(self.io);
     self.directories.ptr(.total_size, index).* = size;
     self.directories.ptr(.total_files, index).* = files;
     self.directories.ptr(.total_dirs, index).* = 1;
 }
 
 pub fn markInaccessible(self: *Context, index: usize) void {
-    self.directories_mutex.lock();
-    defer self.directories_mutex.unlock();
+    self.directories_mutex.lockUncancelable(self.io);
+    defer self.directories_mutex.unlock(self.io);
     const fd_ptr = self.directories.ptr(.fd, index);
     const current_fd = fd_ptr.*;
     if (current_fd != invalid_fd) {
-        std.posix.close(current_fd);
+        (std.Io.Dir{ .handle = current_fd }).close(self.io);
         fd_ptr.* = invalid_fd;
     }
     self.directories.ptr(.fdrefcount, index).store(0, .release);
     self.directories.ptr(.inaccessible, index).* = true;
 }
 
-pub fn addRoot(self: *Context, path: []const u8, dir: std.fs.Dir) !usize {
+pub fn addRoot(self: *Context, path: []const u8, dir: std.Io.Dir) !usize {
     const name_slice = try self.storeName(path);
 
-    self.directories_mutex.lock();
-    defer self.directories_mutex.unlock();
+    self.directories_mutex.lockUncancelable(self.io);
+    defer self.directories_mutex.unlock(self.io);
 
     const index = try self.directories.addOne(self.allocator);
     self.directories.ptr(.parent, index).* = 0;
     self.directories.ptr(.name_slice, index).* = name_slice;
-    self.directories.ptr(.fd, index).* = dir.fd;
+    self.directories.ptr(.fd, index).* = dir.handle;
     self.directories.ptr(.total_size, index).* = 0;
     self.directories.ptr(.total_files, index).* = 0;
     self.directories.ptr(.total_dirs, index).* = 1;
@@ -121,8 +121,8 @@ pub fn setDirectoryFd(self: *Context, index: usize, fd: std.posix.fd_t) void {
 /// Increment reference count to keep a parent directory fd open (thread-safe)
 /// Call when scheduling a child directory that will need openat() from this parent
 pub fn retainParentFd(self: *Context, parent_index: usize) void {
-    self.directories_mutex.lock();
-    defer self.directories_mutex.unlock();
+    self.directories_mutex.lockUncancelable(self.io);
+    defer self.directories_mutex.unlock(self.io);
     self.retainParentFdLocked(parent_index);
 }
 
@@ -151,8 +151,8 @@ pub fn recordLargeFile(
     name: []const u8,
     size: u64,
 ) !void {
-    self.directories_mutex.lock();
-    defer self.directories_mutex.unlock();
+    self.directories_mutex.lockUncancelable(self.io);
+    defer self.directories_mutex.unlock(self.io);
 
     try self.recordLargeFileLocked(directory_index, name, size);
 }
@@ -164,17 +164,17 @@ pub fn shouldExcludeDir(
     child_name: []const u8,
 ) bool {
     if (self.exclude_root_dirs.len == 0) return false;
-    
+
     // Only check exclusions for direct children of root (parent_index == 0)
     if (parent_index != 0) return false;
-    
+
     // Check if child_name matches any excluded directory
     for (self.exclude_root_dirs) |excluded| {
         if (std.mem.eql(u8, child_name, excluded)) {
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -188,9 +188,9 @@ pub fn releaseParentFd(self: *Context, parent_index: usize) void {
         const fd_ptr = self.directories.ptr(.fd, parent_index);
         const fd = fd_ptr.*;
         if (fd != invalid_fd) {
-            self.directories_mutex.lock();
-            defer self.directories_mutex.unlock();
-            std.posix.close(fd);
+            self.directories_mutex.lockUncancelable(self.io);
+            defer self.directories_mutex.unlock(self.io);
+            (std.Io.Dir{ .handle = fd }).close(self.io);
             fd_ptr.* = invalid_fd;
         }
     }
@@ -206,9 +206,9 @@ pub fn releaseParentFdAfterOpen(self: *Context, parent_index: usize) void {
         const fd_ptr = self.directories.ptr(.fd, parent_index);
         const fd = fd_ptr.*;
         if (fd != invalid_fd) {
-            self.directories_mutex.lock();
-            defer self.directories_mutex.unlock();
-            std.posix.close(fd);
+            self.directories_mutex.lockUncancelable(self.io);
+            defer self.directories_mutex.unlock(self.io);
+            (std.Io.Dir{ .handle = fd }).close(self.io);
             fd_ptr.* = invalid_fd;
         }
     }

--- a/src/DirScanner.zig
+++ b/src/DirScanner.zig
@@ -134,6 +134,14 @@ pub const IoPolicyScope = enum(c_int) {
     darwin_bg = 2,
 };
 
+/// `std.posix` no longer wraps `dup`, and the scanner needs a second fd so the
+/// context can close the original while iteration is still in flight.
+pub fn dupFd(fd: std.posix.fd_t) std.posix.UnexpectedError!std.posix.fd_t {
+    const rc = std.c.dup(fd);
+    if (rc >= 0) return rc;
+    return std.posix.unexpectedErrno(std.posix.errno(rc));
+}
+
 /// Set an I/O policy for the current process or thread
 pub extern "c" fn setiopolicy_np(
     iotype: IoPolicyType,
@@ -224,6 +232,17 @@ pub fn EntryFor(mask: AttrGroupMask) type {
     };
 }
 
+/// Read a packed struct using its exact bit width.
+///
+/// `Reader.takeStruct` advances by `@sizeOf`, which for a packed struct rounds
+/// up to the type's alignment — 48 bytes for a 36-byte `Payload`, for instance.
+/// The kernel packs `getattrlistbulk` records with no such padding, so reading
+/// by `@sizeOf` would desynchronize everything after the first field group.
+fn takePacked(r: *std.Io.Reader, comptime T: type) !T {
+    const n = comptime @divExact(@bitSizeOf(T), 8);
+    return @bitCast((try r.takeArray(n)).*);
+}
+
 // ===== Directory Scanner =====
 
 /// Creates a directory scanner type that efficiently iterates over directory entries
@@ -232,15 +251,15 @@ pub fn EntryFor(mask: AttrGroupMask) type {
 const DefaultStatProvider = struct {
     pub const ContextType = void;
 
-    pub fn statAt(_: ContextType, dir_fd: std.posix.fd_t, name: [:0]const u8) posix.FStatAtError!posix.Stat {
-        return posix.fstatat(dir_fd, name, 0);
+    pub fn statAt(_: ContextType, dir_fd: std.posix.fd_t, name: [:0]const u8) SysDispatcher.StatError!SysDispatcher.Stat {
+        return SysDispatcher.statPath(dir_fd, name);
     }
 };
 
 pub const DispatcherStatProvider = struct {
     pub const ContextType = *SysDispatcher.Backend;
 
-    pub fn statAt(dispatcher: ContextType, dir_fd: std.posix.fd_t, name: [:0]const u8) posix.FStatAtError!posix.Stat {
+    pub fn statAt(dispatcher: ContextType, dir_fd: std.posix.fd_t, name: [:0]const u8) SysDispatcher.StatError!SysDispatcher.Stat {
         return dispatcher.statAt(dir_fd, name);
     }
 };
@@ -265,20 +284,22 @@ fn MacOSDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
         pub const Entry = EntryFor(mask);
         pub const Mask = mask;
 
+        io: std.Io,
         fd: std.posix.fd_t,
-        dir: std.fs.Dir,
-        reader: std.io.Reader,
+        dir: std.Io.Dir,
+        reader: std.Io.Reader,
         buf: []u8,
         provider_ctx: Provider.ContextType,
         n: usize = 0, // Number of entries in current batch
 
         /// Initialize a new scanner with a directory file descriptor and buffer
         /// The buffer will be used for storing the bulk attribute results
-        pub fn init(fd: std.posix.fd_t, buf: []u8, provider_ctx: Provider.ContextType) @This() {
+        pub fn init(io: std.Io, fd: std.posix.fd_t, buf: []u8, provider_ctx: Provider.ContextType) @This() {
             return .{
+                .io = io,
                 .fd = fd,
-                .dir = .{ .fd = fd },
-                .reader = std.io.Reader.fixed(buf),
+                .dir = .{ .handle = fd },
+                .reader = std.Io.Reader.fixed(buf),
                 .buf = buf,
                 .provider_ctx = provider_ctx,
             };
@@ -318,7 +339,7 @@ fn MacOSDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
                 }
 
                 self.n = @abs(n);
-                self.reader = std.io.Reader.fixed(self.buf);
+                self.reader = std.Io.Reader.fixed(self.buf);
                 return;
             }
         }
@@ -342,18 +363,17 @@ fn MacOSDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
             // Read record length and prepare reader for this record
             const reclen = try self.reader.peekInt(u32, .little);
             const recbuf = try self.reader.peek(reclen);
-            var rec = std.io.Reader.fixed(recbuf);
+            var rec = std.Io.Reader.fixed(recbuf);
             try self.reader.discardAll(@as(usize, reclen));
             self.n -= 1;
 
             // Parse the payload structure
-            // We use peekStructPointer to get the address for name calculation,
-            // then takeStruct to advance the reader
-            const payload = try rec.peekStructPointer(Payload);
-            _ = try rec.takeStruct(Payload, .little);
+            const payload = try takePacked(&rec, Payload);
 
-            // Extract the name using pointer arithmetic
-            const namerefptr = @as([*]u8, @ptrCast(&payload.name_ref));
+            // An `attrreference_t` offset is relative to the address of the
+            // reference itself, which sits at a fixed offset into the record.
+            const nameref_offset = comptime @divExact(@bitOffsetOf(Payload, "name_ref"), 8);
+            const namerefptr = recbuf.ptr + nameref_offset;
             const namestart = if (payload.name_ref.off < 0)
                 namerefptr - @abs(payload.name_ref.off)
             else
@@ -372,7 +392,7 @@ fn MacOSDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
             // Parse type-specific attributes
             switch (payload.objtype) {
                 VDIR => {
-                    const dir = try rec.takeStruct(DirPayloadFor(mask.dir), .little);
+                    const dir = try takePacked(&rec, DirPayloadFor(mask.dir));
                     entry.details = .{
                         .dir = .{
                             .linkcount = dir.linkcount,
@@ -385,7 +405,7 @@ fn MacOSDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
                     };
                 },
                 VREG => {
-                    const file = try rec.takeStruct(FilePayloadFor(mask.file), .little);
+                    const file = try takePacked(&rec, FilePayloadFor(mask.file));
                     entry.details = .{
                         .file = .{
                             .linkcount = file.linkcount,
@@ -421,21 +441,18 @@ fn PosixDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
         const DirPayload = @FieldType(EntryDetails, "dir");
         const FilePayload = @FieldType(EntryDetails, "file");
 
-        // Check which stat fields are available on this platform
-        const stat_has_nlink = @hasField(posix.Stat, "nlink");
-        const stat_has_blocks = @hasField(posix.Stat, "blocks");
-        const stat_has_blksize = @hasField(posix.Stat, "blksize");
-
-        dir: std.fs.Dir,
-        iterator: std.fs.Dir.Iterator,
+        io: std.Io,
+        dir: std.Io.Dir,
+        iterator: std.Io.Dir.Iterator,
         buf: []u8,
         provider_ctx: Provider.ContextType,
         pending_entry: ?Entry = null,
 
         /// Initialize a new scanner with a directory file descriptor and buffer
-        pub fn init(fd: std.posix.fd_t, buf: []u8, provider_ctx: Provider.ContextType) @This() {
+        pub fn init(io: std.Io, fd: std.posix.fd_t, buf: []u8, provider_ctx: Provider.ContextType) @This() {
             var scanner = @This(){
-                .dir = .{ .fd = fd },
+                .io = io,
+                .dir = .{ .handle = fd },
                 .iterator = undefined,
                 .buf = buf,
                 .provider_ctx = provider_ctx,
@@ -457,13 +474,13 @@ fn PosixDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
         }
 
         /// Stat a file relative to our directory
-        fn statAt(self: *@This(), name: [:0]const u8) !posix.Stat {
-            return try Provider.statAt(self.provider_ctx, self.dir.fd, name);
+        fn statAt(self: *@This(), name: [:0]const u8) !SysDispatcher.Stat {
+            return try Provider.statAt(self.provider_ctx, self.dir.handle, name);
         }
 
         /// Fetch the next directory entry from the iterator
         fn fetchNext(self: *@This()) !?Entry {
-            const dir_entry = (try self.iterator.next()) orelse return null;
+            const dir_entry = (try self.iterator.next(self.io)) orelse return null;
 
             const raw_name = dir_entry.name;
             const name_z = try self.copyName(raw_name);
@@ -495,29 +512,16 @@ fn PosixDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
                     if (needs_dir_stat) {
                         const stat = try self.statAt(name_z);
                         if (comptime mask.dir.linkcount) {
-                            if (stat_has_nlink) {
-                                payload.linkcount = @intCast(stat.nlink);
-                            } else {
-                                payload.linkcount = 0;
-                            }
+                            payload.linkcount = @intCast(stat.nlink);
                         }
                         if (comptime mask.dir.allocsize) {
-                            if (stat_has_blocks) {
-                                const blocks: u64 = @intCast(stat.blocks);
-                                payload.allocsize = blocks * 512;
-                            } else {
-                                payload.allocsize = 0;
-                            }
+                            payload.allocsize = stat.blocks * 512;
                         }
                         if (comptime mask.dir.ioblocksize) {
-                            if (stat_has_blksize) {
-                                payload.ioblocksize = @intCast(stat.blksize);
-                            } else {
-                                payload.ioblocksize = 0;
-                            }
+                            payload.ioblocksize = @intCast(stat.blksize);
                         }
                         if (comptime mask.dir.datalength) {
-                            payload.datalength = @intCast(stat.size);
+                            payload.datalength = stat.size;
                         }
                     }
                     // These aren't available via standard POSIX APIs
@@ -530,22 +534,13 @@ fn PosixDirScanner(mask: AttrGroupMask, comptime Provider: type) type {
                     if (needs_file_stat) {
                         const stat = try self.statAt(name_z);
                         if (comptime mask.file.linkcount) {
-                            if (stat_has_nlink) {
-                                payload.linkcount = @intCast(stat.nlink);
-                            } else {
-                                payload.linkcount = 0;
-                            }
+                            payload.linkcount = @intCast(stat.nlink);
                         }
                         if (comptime mask.file.totalsize) {
-                            payload.totalsize = @intCast(stat.size);
+                            payload.totalsize = stat.size;
                         }
                         if (comptime mask.file.allocsize) {
-                            if (stat_has_blocks) {
-                                const blocks: u64 = @intCast(stat.blocks);
-                                payload.allocsize = blocks * 512;
-                            } else {
-                                payload.allocsize = @intCast(stat.size);
-                            }
+                            payload.allocsize = stat.blocks * 512;
                         }
                     }
                     break :blk .{ .file = payload };
@@ -601,11 +596,11 @@ test "POSIX DirScanner iterates entries with requested metadata" {
 
     const Scanner = DirScanner(mask);
     var name_buf: [256]u8 = undefined;
-    var iterable_dir = try tmp.dir.openDir(".", .{ .iterate = true });
-    const dup_fd = try std.posix.dup(iterable_dir.fd);
-    iterable_dir.close();
-    var scanner = Scanner.init(dup_fd, name_buf[0..], @as(void, {}));
-    defer scanner.dir.close();
+    var iterable_dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true });
+    const dup_fd = try dupFd(iterable_dir.handle);
+    iterable_dir.close(std.testing.io);
+    var scanner = Scanner.init(std.testing.io, dup_fd, name_buf[0..], @as(void, {}));
+    defer scanner.dir.close(std.testing.io);
 
     var saw_file = false;
     var saw_dir = false;
@@ -645,11 +640,11 @@ test "POSIX DirScanner copyName reports buffer exhaustion" {
     const Scanner = DirScanner(mask);
 
     var tiny_buf: [3]u8 = undefined;
-    var iterable_dir = try tmp.dir.openDir(".", .{ .iterate = true });
-    const dup_fd = try std.posix.dup(iterable_dir.fd);
-    iterable_dir.close();
-    var scanner = Scanner.init(dup_fd, tiny_buf[0..], @as(void, {}));
-    defer scanner.dir.close();
+    var iterable_dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true });
+    const dup_fd = try dupFd(iterable_dir.handle);
+    iterable_dir.close(std.testing.io);
+    var scanner = Scanner.init(std.testing.io, dup_fd, tiny_buf[0..], @as(void, {}));
+    defer scanner.dir.close(std.testing.io);
 
     try std.testing.expectError(error.BufferTooSmall, scanner.copyName("long"));
     const short_name = try scanner.copyName("ok");

--- a/src/DiskScan.zig
+++ b/src/DiskScan.zig
@@ -17,6 +17,9 @@ const Self = @This();
 /// Memory allocator for all dynamic allocations during the scan
 allocator: std.mem.Allocator,
 
+/// I/O implementation used for filesystem access, progress, and worker threads
+io: std.Io,
+
 /// Whether to skip hidden files and directories (starting with '.')
 skip_hidden: bool = false,
 
@@ -80,7 +83,7 @@ const Summary = struct {
 };
 
 const RootOpenResult = struct {
-    dir: ?std.fs.Dir,
+    dir: ?std.Io.Dir,
     inaccessible: bool,
 };
 
@@ -94,10 +97,6 @@ pub const ScanResults = struct {
     elapsed_ns: u64,
     totals: DirectoryTotals,
 };
-
-var stdout_buffer: [4096]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
 
 pub const RunOptions = struct {
     /// When true, generate the human readable summary and print it to stdout.
@@ -126,18 +125,18 @@ const PlatformConfig = struct {
 
 fn createScanContext(
     self: *Self,
-    pool: *std.Thread.Pool,
-    wait_group: *std.Thread.WaitGroup,
+    io: std.Io,
+    worker_group: *std.Io.Group,
     queue_progress: *std.Progress.Node,
     task_queue: *TaskQueue,
 ) Context {
     return Context{
         .allocator = self.allocator,
-        .pool = pool,
+        .io = io,
         .task_queue = task_queue,
         .directories = &self.directories,
         .names_buffer = &self.names,
-        .wait_group = wait_group,
+        .worker_group = worker_group,
         .progress_node = queue_progress.*,
         .errprogress = self.progress_root.start("errors", 0),
         .skip_hidden = self.skip_hidden,
@@ -150,8 +149,8 @@ fn createScanContext(
 fn initializeRootDirectory(self: *Self, ctx: *Context) !void {
     self.progress_root.setEstimatedTotalItems(1);
 
-    var rootdir = try std.fs.cwd().openDir(self.root, .{ .iterate = true });
-    errdefer rootdir.close();
+    var rootdir = try std.Io.Dir.cwd().openDir(self.io, self.root, .{ .iterate = true });
+    errdefer rootdir.close(self.io);
 
     const rootidx = try ctx.addRoot(".", rootdir);
 
@@ -167,22 +166,25 @@ fn gatherPhase(self: *Self) !void {
     var queue_progress = self.progress_root.start("Work queue", 0);
     errdefer queue_progress.end();
 
-    var wait_group = std.Thread.WaitGroup{};
+    // Workers are long-running loops that block on the task queue, so they must
+    // each get their own thread: `Group.concurrent`, never `Group.async` (which
+    // may run the task inline when the pool is saturated).
+    const n_workers = if (builtin.single_threaded)
+        1
+    else
+        std.Thread.getCpuCount() catch 1;
 
-    var worker_pool: std.Thread.Pool = undefined;
-    try worker_pool.init(.{
-        .allocator = self.allocator,
-        .stack_size = 32 * 1024 * 1024,
-    });
-    defer worker_pool.deinit();
+    const io = self.io;
+    var worker_group: std.Io.Group = .init;
 
     var task_queue = TaskQueue{
+        .io = io,
         .progress = &queue_progress,
     };
 
     var ctx = self.createScanContext(
-        &worker_pool,
-        &wait_group,
+        io,
+        &worker_group,
         &queue_progress,
         &task_queue,
     );
@@ -190,13 +192,11 @@ fn gatherPhase(self: *Self) !void {
 
     try self.initializeRootDirectory(&ctx);
 
-    const n_workers = if (builtin.single_threaded) 1 else worker_pool.threads.len;
-
     for (0..n_workers) |_| {
-        worker_pool.spawnWg(&wait_group, Worker.directoryWorker, .{&ctx});
+        try worker_group.concurrent(io, Worker.directoryWorker, .{&ctx});
     }
 
-    defer wait_group.wait();
+    defer worker_group.await(io) catch {};
 }
 
 fn writeFullPath(
@@ -248,7 +248,7 @@ pub fn freeNameBuffers(self: *Self) void {
 test "path helpers use shared directory data" {
     const allocator = std.testing.allocator;
 
-    var disk_scan = Self{ .allocator = allocator };
+    var disk_scan = Self{ .allocator = allocator, .io = std.testing.io };
     defer {
         disk_scan.freeNameBuffers();
         disk_scan.directories.deinit(allocator);
@@ -305,12 +305,12 @@ test "threaded disk scan can repeatedly scan populated directory trees" {
     for (0..top_dir_count) |top_index| {
         var dir_buf: [32]u8 = undefined;
         const dir_name = try std.fmt.bufPrint(&dir_buf, "dir{d}", .{top_index});
-        try tmp.dir.makePath(dir_name);
+        try tmp.dir.createDirPath(std.testing.io, dir_name);
 
         for (0..sub_dir_count) |sub_index| {
             var sub_buf: [64]u8 = undefined;
             const sub_name = try std.fmt.bufPrint(&sub_buf, "{s}/sub{d}", .{ dir_name, sub_index });
-            try tmp.dir.makePath(sub_name);
+            try tmp.dir.createDirPath(std.testing.io, sub_name);
 
             for (0..files_per_subdir) |file_index| {
                 var file_buf: [96]u8 = undefined;
@@ -319,19 +319,19 @@ test "threaded disk scan can repeatedly scan populated directory trees" {
                 var contents_buf: [32]u8 = undefined;
                 const contents = try std.fmt.bufPrint(&contents_buf, "data-{d}-{d}-{d}", .{ top_index, sub_index, file_index });
 
-                try tmp.dir.writeFile(.{ .sub_path = file_path, .data = contents });
+                try tmp.dir.writeFile(std.testing.io, .{ .sub_path = file_path, .data = contents });
             }
         }
     }
 
-    const root_path = try tmp.dir.realpathAlloc(allocator, ".");
+    const root_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(root_path);
 
     const expected_files = top_dir_count * sub_dir_count * files_per_subdir;
     const expected_directories = 1 + top_dir_count + (top_dir_count * sub_dir_count);
 
     for (0..20) |_| {
-        var disk_scan = Self{ .allocator = allocator, .root = root_path };
+        var disk_scan = Self{ .allocator = allocator, .io = std.testing.io, .root = root_path };
         defer {
             disk_scan.freeNameBuffers();
             disk_scan.directories.deinit(allocator);
@@ -380,7 +380,7 @@ const StatsAggregator = struct {
 
 const SummaryBuilder = struct {
     fn buildTopLevelEntries(self: *Self) !std.ArrayList(SummaryEntry) {
-        var entries = std.ArrayList(SummaryEntry){};
+        var entries: std.ArrayList(SummaryEntry) = .empty;
         errdefer Summary.freeEntryList(self.allocator, &entries);
         self.progress_root.setName("Building paths");
         const len_snapshot = self.directories.len();
@@ -409,9 +409,9 @@ const SummaryBuilder = struct {
     }
 
     fn buildHeaviestEntries(self: *Self, max_entries: usize) !std.ArrayList(SummaryEntry) {
-        if (max_entries == 0) return std.ArrayList(SummaryEntry){};
+        if (max_entries == 0) return .empty;
 
-        var top_indexes = std.ArrayList(usize){};
+        var top_indexes: std.ArrayList(usize) = .empty;
         defer top_indexes.deinit(self.allocator);
 
         const len_snapshot = self.directories.len();
@@ -423,7 +423,7 @@ const SummaryBuilder = struct {
             try SummaryBuilder.insertTopIndex(self, &top_indexes, idx, max_entries, size);
         }
 
-        var entries = std.ArrayList(SummaryEntry){};
+        var entries: std.ArrayList(SummaryEntry) = .empty;
         errdefer Summary.freeEntryList(self.allocator, &entries);
         try entries.ensureTotalCapacityPrecise(self.allocator, top_indexes.items.len);
 
@@ -440,9 +440,9 @@ const SummaryBuilder = struct {
     }
 
     fn buildLargeFileEntries(self: *Self, max_entries: usize) !std.ArrayList(FileSummaryEntry) {
-        if (max_entries == 0) return std.ArrayList(FileSummaryEntry){};
+        if (max_entries == 0) return .empty;
 
-        var top_indexes = std.ArrayList(usize){};
+        var top_indexes: std.ArrayList(usize) = .empty;
         defer top_indexes.deinit(self.allocator);
 
         const slices = self.large_files.slice();
@@ -455,7 +455,7 @@ const SummaryBuilder = struct {
             try SummaryBuilder.insertFileIndex(self, &top_indexes, idx, max_entries, sizes);
         }
 
-        var entries = std.ArrayList(FileSummaryEntry){};
+        var entries: std.ArrayList(FileSummaryEntry) = .empty;
         errdefer Summary.freeFileEntryList(self.allocator, &entries);
         try entries.ensureTotalCapacityPrecise(self.allocator, top_indexes.items.len);
 
@@ -567,9 +567,9 @@ const SummaryBuilder = struct {
 pub fn performScan(self: *Self) !ScanResults {
     self.large_files.clearRetainingCapacity();
 
-    var timer = try std.time.Timer.start();
+    const started = std.Io.Clock.awake.now(self.io);
     try self.gatherPhase();
-    const elapsed_ns = timer.read();
+    const elapsed_ns: u64 = @intCast(started.untilNow(self.io, .awake).toNanoseconds());
 
     StatsAggregator.aggregateUp(self);
     const totals = StatsAggregator.extractTotals(self);
@@ -582,9 +582,9 @@ pub fn performScan(self: *Self) !ScanResults {
 
 pub fn generateSummary(self: *Self) !Summary {
     var summary = Summary{
-        .top_level = std.ArrayList(SummaryEntry){},
-        .heaviest = std.ArrayList(SummaryEntry){},
-        .large_files = std.ArrayList(FileSummaryEntry){},
+        .top_level = .empty,
+        .heaviest = .empty,
+        .large_files = .empty,
     };
     errdefer summary.deinit(self.allocator);
 
@@ -620,6 +620,10 @@ pub fn reportResults(self: *Self, results: ScanResults, summary: Summary) !void 
     );
     defer heaviest.deinit(self.allocator);
 
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(self.io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
     try Reporter.printHeader(stdout, self.root, results);
     try Reporter.printTopLevelDirectories(stdout, report_data, top_level);
     try Reporter.printHeaviestDirectories(stdout, report_data, heaviest);
@@ -629,9 +633,9 @@ pub fn reportResults(self: *Self, results: ScanResults, summary: Summary) !void 
 
 fn runWithOptions(self: *Self, options: RunOptions) !void {
     // Initialize progress tracking
-    var progress = std.Progress.start(.{
+    var progress = std.Progress.start(self.io, .{
         .root_name = "wtfs",
-        .refresh_rate_ns = 80 * std.time.ns_per_ms,
+        .refresh_rate_ns = .fromMilliseconds(80),
     });
     errdefer progress.end();
     self.progress_root = progress;
@@ -679,7 +683,7 @@ pub fn writeBinaryResults(
     try writer.writeStruct(results.totals, .little);
 
     // Build name buffer from segmented storage
-    var name_buffer = std.ArrayListUnmanaged(u8){};
+    var name_buffer: std.ArrayList(u8) = .empty;
     defer name_buffer.deinit(self.allocator);
 
     const dir_len = self.directories.len();
@@ -793,7 +797,7 @@ pub fn readBinaryResults(
     try reader.readSliceAll(name_buffer);
 
     // Store names in segmented buffer and collect slice indices
-    var name_slices = std.ArrayList(u32){};
+    var name_slices: std.ArrayList(u32) = .empty;
     defer name_slices.deinit(self.allocator);
 
     var name_offset: usize = 0;

--- a/src/Report.zig
+++ b/src/Report.zig
@@ -8,7 +8,7 @@ const SummaryEntry = DiskScan.SummaryEntry;
 const FileSummaryEntry = DiskScan.FileSummaryEntry;
 const DirectoryTotals = DiskScan.DirectoryTotals;
 const ScanResults = DiskScan.ScanResults;
-const Writer = std.io.Writer;
+const Writer = std.Io.Writer;
 const Allocator = std.mem.Allocator;
 
 const TabWriter = Tabular.TabWriter;
@@ -67,7 +67,7 @@ pub fn buildTopLevelSummary(
     entries: []const SummaryEntry,
     limit: usize,
 ) !TopLevelSummary {
-    var summary = TopLevelSummary{ .rows = std.ArrayList(TopLevelRow){} };
+    var summary = TopLevelSummary{ .rows = .empty };
     errdefer summary.rows.deinit(allocator);
 
     if (entries.len == 0) return summary;
@@ -163,7 +163,7 @@ pub fn buildHeaviestSummary(
     data: ReportData,
     entries: []const SummaryEntry,
 ) !HeaviestSummary {
-    var summary = HeaviestSummary{ .rows = std.ArrayList(HeaviestRow){} };
+    var summary = HeaviestSummary{ .rows = .empty };
     errdefer summary.rows.deinit(allocator);
 
     if (entries.len == 0) return summary;
@@ -192,7 +192,7 @@ pub fn buildHeaviestSummary(
 
             const gop = try child_map.getOrPut(parent_index);
             if (!gop.found_existing) {
-                gop.value_ptr.* = std.ArrayList(usize){};
+                gop.value_ptr.* = .empty;
             }
             const children_ptr = gop.value_ptr;
             if (std.mem.indexOfScalar(usize, children_ptr.items, current) == null) {

--- a/src/SegmentedMultiArray.zig
+++ b/src/SegmentedMultiArray.zig
@@ -24,12 +24,7 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         const Elem = switch (@typeInfo(T)) {
             .@"struct" => T,
             .@"union" => |u| struct {
-                pub const Bare = @Type(.{ .@"union" = .{
-                    .layout = u.layout,
-                    .tag_type = null,
-                    .fields = u.fields,
-                    .decls = &.{},
-                } });
+                pub const Bare = meta.BareUnion(T);
                 pub const Tag = u.tag_type orelse
                     @compileError("no untagged unions");
                 tags: Tag,
@@ -55,13 +50,14 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         };
 
         pub const Field = meta.FieldEnum(Elem);
-        const fields = meta.fields(Elem);
+        const field_names = @typeInfo(Elem).@"struct".field_names;
+        const field_types = @typeInfo(Elem).@"struct".field_types;
 
         fn FieldType(comptime f: Field) type {
             return @FieldType(Elem, @tagName(f));
         }
         fn FieldTypeI(comptime i: usize) type {
-            return @FieldType(Elem, fields[i].name);
+            return @FieldType(Elem, field_names[i]);
         }
 
         // ----- Storage: per-field shelves (each shelf is a contiguous []FieldType) -----
@@ -69,7 +65,7 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
             addr: usize,
         };
 
-        shelves: [fields.len][MAX_SHELVES]ShelfEntry = undefined,
+        shelves: [field_names.len][MAX_SHELVES]ShelfEntry = undefined,
         latch: CapacityLatch = .{},
         shelf_count: std.atomic.Value(usize) = .init(0),
 
@@ -79,8 +75,8 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         /// Existing field pointers become invalid once this returns.
         pub fn deinit(self: *Self, alloc: Allocator) void {
             const shelf_count = self.shelf_count.load(.acquire);
-            inline for (fields, 0..) |f, fi| {
-                if (@sizeOf(f.type) == 0) continue;
+            inline for (field_names, field_types, 0..) |_, f_type, fi| {
+                if (@sizeOf(f_type) == 0) continue;
                 for (0..shelf_count) |s| {
                     const addr = self.shelves[fi][s].addr;
                     if (addr == 0) continue;
@@ -221,11 +217,11 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
             cap: usize,
             shelf_count: usize,
             shelves: [MAX_SHELVES]DebugShelf,
-            field_bytes: [fields.len]usize,
+            field_bytes: [field_names.len]usize,
             total_bytes: usize,
 
             pub fn bytesForField(self: @This(), comptime field: Field) usize {
-                return self.field_bytes[@intFromEnum(field)];
+                return self.field_bytes[@backingInt(field)];
             }
         };
 
@@ -239,7 +235,7 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
                 .total_bytes = 0,
             };
 
-            inline for (fields, 0..) |_, fi| {
+            inline for (0..field_names.len) |fi| {
                 stats.field_bytes[fi] = 0;
             }
             var s: usize = 0;
@@ -254,9 +250,9 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
                 const take = @min(rows, remaining);
                 stats.shelves[shelf_index] = .{ .capacity = rows, .used = take };
 
-                inline for (fields, 0..) |f, fi| {
-                    if (@sizeOf(f.type) == 0) continue;
-                    const bytes = take * @sizeOf(f.type);
+                inline for (field_names, field_types, 0..) |_, f_type, fi| {
+                    if (@sizeOf(f_type) == 0) continue;
+                    const bytes = take * @sizeOf(f_type);
                     stats.field_bytes[fi] += bytes;
                     stats.total_bytes += bytes;
                 }
@@ -285,9 +281,9 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
             if (s >= MAX_SHELVES) return error.OutOfMemory;
 
             const rows = shelfSizeByIndex(@intCast(s));
-            inline for (fields, 0..) |f, fi| {
-                if (@sizeOf(f.type) == 0) continue;
-                const buf = try alloc.alloc(f.type, rows);
+            inline for (field_names, field_types, 0..) |_, f_type, fi| {
+                if (@sizeOf(f_type) == 0) continue;
+                const buf = try alloc.alloc(f_type, rows);
                 self.shelves[fi][s].addr = @intFromPtr(buf.ptr);
             }
 
@@ -339,7 +335,7 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         /// Pointers remain valid across future growth because shelves are never relocated.
         pub fn ptr(self: *Self, comptime field: Field, idx: usize) *FieldType(field) {
             std.debug.assert(idx < self.len());
-            const fi = @intFromEnum(field);
+            const fi = @backingInt(field);
             const sb = shelfIndex(idx);
             const bi = boxIndex(idx, sb);
 
@@ -360,15 +356,15 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         pub fn get(self: *Self, idx: usize) T {
             std.debug.assert(idx < self.len());
             var e: Elem = undefined;
-            inline for (fields, 0..) |f, fi| {
-                if (@sizeOf(f.type) != 0) {
+            inline for (field_names, field_types, 0..) |f_name, f_type, fi| {
+                if (@sizeOf(f_type) != 0) {
                     const sb = shelfIndex(idx);
                     const bi = boxIndex(idx, sb);
                     const shelf_pos: usize = @intCast(sb);
                     const entry = self.shelves[fi][shelf_pos];
                     std.debug.assert(entry.addr != 0);
                     const base: [*]FieldTypeI(fi) = @as([*]FieldTypeI(fi), @ptrFromInt(entry.addr));
-                    @field(e, f.name) = base[bi];
+                    @field(e, f_name) = base[bi];
                 } else {
                     // ZST: leave default
                 }
@@ -392,13 +388,13 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
             };
             const sb = shelfIndex(idx);
             const bi = boxIndex(idx, sb);
-            inline for (fields, 0..) |f, fi| {
-                if (@sizeOf(f.type) == 0) continue;
+            inline for (field_names, field_types, 0..) |f_name, f_type, fi| {
+                if (@sizeOf(f_type) == 0) continue;
                 const shelf_pos: usize = @intCast(sb);
                 const entry = self.shelves[fi][shelf_pos];
                 std.debug.assert(entry.addr != 0);
                 const base: [*]FieldTypeI(fi) = @as([*]FieldTypeI(fi), @ptrFromInt(entry.addr));
-                base[bi] = @field(e, f.name);
+                base[bi] = @field(e, f_name);
             }
         }
 
@@ -422,10 +418,10 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
             try mal.ensureTotalCapacity(alloc, len_snapshot);
             mal.len = len_snapshot;
             var out = mal.slice();
-            inline for (fields, 0..) |f, fi| {
-                if (@sizeOf(f.type) == 0) continue;
-                const dst = out.items(@enumFromInt(fi));
-                const elem_sz = @sizeOf(f.type);
+            inline for (field_names, field_types, 0..) |_, f_type, fi| {
+                if (@sizeOf(f_type) == 0) continue;
+                const dst = out.items(@fromBackingInt(@intCast(fi)));
+                const elem_sz = @sizeOf(f_type);
                 const dst_bytes = mem.sliceAsBytes(dst);
                 var off: usize = 0;
                 const shelf_count = self.shelf_count.load(.acquire);
@@ -473,8 +469,8 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
 
                 var shelfslices: [MAX_SHELVES][]FT = undefined;
                 for (0..Self.shelfIndex(self.len - 1)) |i| {
-                    var entries: [fields.len]ShelfEntry = undefined;
-                    inline for (0..fields.len) |fi| {
+                    var entries: [field_names.len]ShelfEntry = undefined;
+                    inline for (0..field_names.len) |fi| {
                         entries[fi] = self.parent.shelves[fi][i];
                     }
                     if (entries[0].addr == 0) {
@@ -497,7 +493,7 @@ pub fn SegmentedMultiArray(comptime T: type, comptime PREALLOC: usize) type {
         /// Typed segmented field view used by `itemsSeg`.
         pub fn SegView(comptime field: Field) type {
             const ViewedFieldType = FieldType(field);
-            const field_index = @intFromEnum(field);
+            const field_index = @backingInt(field);
             return struct {
                 parent: *Self,
 
@@ -816,10 +812,7 @@ test "SegmentedMultiArray concurrent reserveBlock" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     const Row = struct { writer: usize, value: usize };
-    var thread_safe_allocator = std.heap.ThreadSafeAllocator{
-        .child_allocator = testing.allocator,
-    };
-    const alloc = thread_safe_allocator.allocator();
+    const alloc = testing.allocator;
 
     var sma = SegmentedMultiArray(Row, 0){};
     defer sma.deinit(alloc);
@@ -858,7 +851,7 @@ test "SegmentedMultiArray concurrent reserveBlock" {
     defer testing.allocator.free(seen);
     @memset(seen, false);
 
-    var per_writer = [_]usize{0} ** thread_count;
+    var per_writer: [thread_count]usize = @splat(0);
 
     for (0..total) |i| {
         const row = sma.get(i);
@@ -880,10 +873,7 @@ test "SegmentedMultiArray concurrent addOne" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     const Row = struct { writer: usize, value: usize };
-    var thread_safe_allocator = std.heap.ThreadSafeAllocator{
-        .child_allocator = testing.allocator,
-    };
-    const alloc = thread_safe_allocator.allocator();
+    const alloc = testing.allocator;
 
     var sma = SegmentedMultiArray(Row, 16){};
     defer sma.deinit(alloc);
@@ -925,7 +915,7 @@ test "SegmentedMultiArray concurrent addOne" {
     defer testing.allocator.free(seen);
     @memset(seen, false);
 
-    var per_writer = [_]usize{0} ** thread_count;
+    var per_writer: [thread_count]usize = @splat(0);
 
     for (0..total) |i| {
         const row = sma.get(i);

--- a/src/SegmentedStringBuffer.zig
+++ b/src/SegmentedStringBuffer.zig
@@ -315,10 +315,10 @@ test "SegmentedStringBuffer spans multiple shelves" {
     const allocator = std.testing.allocator;
     defer buffer.deinit(allocator);
 
-    const first_data = "a" ** (SegmentedStringBuffer.first_shelf_bytes - 1); // Leave room for null
-    const first = try buffer.append(allocator, first_data);
+    const first_data: [SegmentedStringBuffer.first_shelf_bytes - 1]u8 = @splat('a'); // Leave room for null
+    const first = try buffer.append(allocator, &first_data);
     try std.testing.expectEqual(@as(usize, 1), buffer.shelfCount());
-    try std.testing.expectEqualStrings(first_data, buffer.get(first));
+    try std.testing.expectEqualStrings(&first_data, buffer.get(first));
 
     const second_len = SegmentedStringBuffer.first_shelf_bytes + 128;
     const payload = try allocator.alloc(u8, second_len);
@@ -349,9 +349,8 @@ test "SegmentedStringBuffer append keeps entries within shelf" {
 }
 
 test "SegmentedStringBuffer concurrent append" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
-    defer std.debug.assert(gpa.deinit() == .ok);
-    const allocator = gpa.allocator();
+    // `std.testing.allocator` is a thread-safe `SafeAllocator`.
+    const allocator = std.testing.allocator;
 
     var buffer = SegmentedStringBuffer.empty;
     defer buffer.deinit(allocator);

--- a/src/SysDispatcher.zig
+++ b/src/SysDispatcher.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 
 pub const Config = struct {
@@ -10,6 +11,69 @@ pub const Config = struct {
 pub const StatRequest = void;
 
 pub const Backend = SyncBackend;
+
+/// The subset of file metadata the scanner needs, normalized across platforms.
+///
+/// `std.Io.File.Stat` deliberately omits the allocated-block count, but that is
+/// exactly what makes the totals agree with `du`, so we go under it.
+pub const Stat = struct {
+    nlink: u64,
+    /// Apparent size in bytes.
+    size: u64,
+    /// Blocks of 512 bytes actually allocated. Differs from `size` for sparse,
+    /// compressed, and inline-data files.
+    blocks: u64,
+    /// Preferred I/O block size.
+    blksize: u64,
+};
+
+pub const StatError = error{
+    AccessDenied,
+    FileNotFound,
+    SymLinkLoop,
+    NameTooLong,
+    SystemResources,
+} || posix.UnexpectedError;
+
+/// `std.posix` no longer wraps `fstatat`, and on Linux `std.posix.Stat` is
+/// `void` because the kernel interface there is `statx`. Both platforms link
+/// libc for us, so call through to the appropriate one directly.
+pub fn statPath(dir_fd: posix.fd_t, name: [:0]const u8) StatError!Stat {
+    if (builtin.os.tag == .linux) {
+        var stx: std.os.linux.Statx = undefined;
+        const want: std.os.linux.STATX = .{ .NLINK = true, .SIZE = true, .BLOCKS = true };
+        const rc = std.c.statx(dir_fd, name.ptr, 0, want, &stx);
+        try checkErrno(posix.errno(rc));
+        return .{
+            .nlink = stx.nlink,
+            .size = stx.size,
+            .blocks = stx.blocks,
+            .blksize = stx.blksize,
+        };
+    }
+
+    const fstatat_sym = if (posix.lfs64_abi) posix.system.fstatat64 else posix.system.fstatat;
+    var st: posix.system.Stat = undefined;
+    try checkErrno(posix.errno(fstatat_sym(dir_fd, name.ptr, &st, 0)));
+    return .{
+        .nlink = @intCast(st.nlink),
+        .size = @intCast(st.size),
+        .blocks = @intCast(st.blocks),
+        .blksize = @intCast(st.blksize),
+    };
+}
+
+fn checkErrno(err: posix.E) StatError!void {
+    return switch (err) {
+        .SUCCESS => {},
+        .ACCES, .PERM => error.AccessDenied,
+        .NOENT, .NOTDIR => error.FileNotFound,
+        .LOOP => error.SymLinkLoop,
+        .NAMETOOLONG => error.NameTooLong,
+        .NOMEM => error.SystemResources,
+        else => posix.unexpectedErrno(err),
+    };
+}
 
 const SyncBackend = struct {
     pub fn init(_: *SyncBackend, config: Config) !void {
@@ -30,8 +94,8 @@ const SyncBackend = struct {
         _: *SyncBackend,
         dir_fd: posix.fd_t,
         name: [:0]const u8,
-    ) posix.FStatAtError!posix.Stat {
-        return posix.fstatat(dir_fd, name, 0);
+    ) StatError!Stat {
+        return statPath(dir_fd, name);
     }
 
     pub fn directoryFlags() posix.O {

--- a/src/TaskQueue.zig
+++ b/src/TaskQueue.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
 const TaskQueue = @This();
 
+io: std.Io,
 progress: *std.Progress.Node,
 high_watermark: std.atomic.Value(usize) = .init(0),
-mutex: std.Thread.Mutex = .{},
-cond: std.Thread.Condition = .{},
-items: std.ArrayList(usize) = .{},
+mutex: std.Io.Mutex = .init,
+cond: std.Io.Condition = .init,
+items: std.ArrayList(usize) = .empty,
 done: bool = false,
 
 pub fn deinit(self: *TaskQueue, allocator: std.mem.Allocator) void {
@@ -13,22 +14,22 @@ pub fn deinit(self: *TaskQueue, allocator: std.mem.Allocator) void {
 }
 
 pub fn push(self: *TaskQueue, allocator: std.mem.Allocator, value: usize) !void {
-    self.mutex.lock();
-    defer self.mutex.unlock();
+    self.mutex.lockUncancelable(self.io);
+    defer self.mutex.unlock(self.io);
     const current_len = self.items.items.len;
     self.progress.setCompletedItems(current_len + 1);
     _ = self.high_watermark.fetchMax(current_len + 1, .acq_rel);
 
     try self.items.append(allocator, value);
-    self.cond.signal();
+    self.cond.signal(self.io);
 }
 
 pub fn pop(self: *TaskQueue) ?usize {
-    self.mutex.lock();
-    defer self.mutex.unlock();
+    self.mutex.lockUncancelable(self.io);
+    defer self.mutex.unlock(self.io);
 
     while (self.items.items.len == 0 and !self.done) {
-        self.cond.wait(&self.mutex);
+        self.cond.waitUncancelable(self.io, &self.mutex);
     }
 
     if (self.items.items.len == 0) {
@@ -40,8 +41,8 @@ pub fn pop(self: *TaskQueue) ?usize {
 }
 
 pub fn close(self: *TaskQueue) void {
-    self.mutex.lock();
+    self.mutex.lockUncancelable(self.io);
     self.done = true;
-    self.mutex.unlock();
-    self.cond.broadcast();
+    self.mutex.unlock(self.io);
+    self.cond.broadcast(self.io);
 }

--- a/src/Worker.zig
+++ b/src/Worker.zig
@@ -65,7 +65,7 @@ progress_writer: std.Io.Writer,
 scan_buffer: [1024 * 1024]u8,
 
 /// Performance tracking
-timer: std.time.Timer,
+started_at: std.Io.Timestamp,
 items_processed: usize,
 
 // ===== Main Worker Loop =====
@@ -84,9 +84,7 @@ pub fn directoryWorker(ctx: *Context) void {
         .progress_buffer = undefined,
         .progress_writer = undefined,
         .scan_buffer = undefined,
-        .timer = std.time.Timer.start() catch |e| {
-            std.debug.panic("timer start failed {t}", .{e});
-        },
+        .started_at = std.Io.Clock.awake.now(ctx.io),
         .items_processed = 0,
     };
     defer worker.path_buffer.deinit(worker.allocator);
@@ -205,11 +203,11 @@ fn scanDirectory(
     metrics: *ScanMetrics,
 ) !void {
     // Iterate using a duplicate so the context can safely close the original fd.
-    const iter_fd = posix.dup(dir_fd) catch |err| {
+    const iter_fd = dirscan.dupFd(dir_fd) catch |err| {
         return self.handleScanError(index, err);
     };
-    var scanner = Scanner.init(iter_fd, &self.scan_buffer, &self.dispatcher);
-    defer scanner.dir.close();
+    var scanner = Scanner.init(self.ctx.io, iter_fd, &self.scan_buffer, &self.dispatcher);
+    defer scanner.dir.close(self.ctx.io);
 
     self.ctx.retainParentFd(index);
     defer self.ctx.releaseParentFd(index);
@@ -302,8 +300,8 @@ fn processEntry(
 pub fn addChild(self: *Worker, parent_index: usize, name: []const u8) !usize {
     const name_slice = try self.ctx.storeName(name);
 
-    self.ctx.directories_mutex.lock();
-    defer self.ctx.directories_mutex.unlock();
+    self.ctx.directories_mutex.lockUncancelable(self.ctx.io);
+    defer self.ctx.directories_mutex.unlock(self.ctx.io);
     const index = try self.ctx.directories.addOne(self.allocator);
     self.ctx.directories.ptr(.parent, index).* = @intCast(parent_index);
     self.ctx.directories.ptr(.name_slice, index).* = name_slice;

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,24 +20,26 @@ const TabWriter = Tabular.TabWriter;
 const Column = Tabular.Column;
 
 var stderr_buffer: [4096]u8 = undefined;
-var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+var stderr_writer: std.Io.File.Writer = undefined;
 const stderr = &stderr_writer.interface;
-pub fn main() !void {
-    const gpa = std.heap.c_allocator;
-    var arena = std.heap.ArenaAllocator.init(gpa);
-    defer arena.deinit();
-    var thread_safe_arena = std.heap.ThreadSafeAllocator{
-        .child_allocator = arena.allocator(),
-    };
-    const allocator = thread_safe_arena.allocator();
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    // The arena is threadsafe, and lives for the whole process.
+    const allocator = init.arena.allocator();
 
-    const exe_name = if (args.len > 0)
-        std.mem.sliceTo(args[0], 0)
-    else
-        "wtfs";
+    stderr_writer = std.Io.File.stderr().writer(io, &stderr_buffer);
+
+    var args_it = try std.process.Args.Iterator.initAllocator(init.minimal.args, allocator);
+    defer args_it.deinit();
+
+    var args_list: std.ArrayList([]const u8) = .empty;
+    while (args_it.next()) |arg| {
+        try args_list.append(allocator, try allocator.dupe(u8, arg));
+    }
+    const args = args_list.items;
+
+    const exe_name = if (args.len > 0) args[0] else "wtfs";
 
     var skip_hidden = false;
     var root_arg: ?[]const u8 = null;
@@ -55,7 +57,7 @@ pub fn main() !void {
 
     var arg_index: usize = 1;
     while (arg_index < args.len) : (arg_index += 1) {
-        const arg = std.mem.sliceTo(args[arg_index], 0);
+        const arg = args[arg_index];
         if (std.mem.eql(u8, arg, "--skip-hidden")) {
             skip_hidden = true;
             continue;
@@ -66,7 +68,7 @@ pub fn main() !void {
                 try printUsage(exe_name);
                 return;
             }
-            binary_output = std.mem.sliceTo(args[arg_index], 0);
+            binary_output = args[arg_index];
             continue;
         }
         if (std.mem.eql(u8, arg, "--binary-input")) {
@@ -75,7 +77,7 @@ pub fn main() !void {
                 try printUsage(exe_name);
                 return;
             }
-            binary_input = std.mem.sliceTo(args[arg_index], 0);
+            binary_input = args[arg_index];
             continue;
         }
         if (std.mem.eql(u8, arg, "--large-file-threshold")) {
@@ -84,7 +86,7 @@ pub fn main() !void {
                 try printUsage(exe_name);
                 return;
             }
-            const value_arg = std.mem.sliceTo(args[arg_index], 0);
+            const value_arg = args[arg_index];
             large_file_threshold = parseSize(value_arg) catch {
                 try stderr.print("invalid size for --large-file-threshold: {s}\n", .{value_arg});
                 try printUsage(exe_name);
@@ -129,7 +131,7 @@ pub fn main() !void {
     }
 
     if (dump_structs) {
-        try dumpStructLayouts();
+        try dumpStructLayouts(io);
         return;
     }
 
@@ -159,6 +161,7 @@ pub fn main() !void {
 
     var diskScan = DiskScan{
         .allocator = allocator,
+        .io = io,
         .skip_hidden = skip_hidden,
         .root = root,
         .large_file_threshold = large_file_threshold,
@@ -172,11 +175,11 @@ pub fn main() !void {
 
     if (binary_input) |path| {
         // Load from binary dump
-        var binary_file = try std.fs.cwd().openFile(path, .{});
-        defer binary_file.close();
+        var binary_file = try std.Io.Dir.cwd().openFile(io, path, .{});
+        defer binary_file.close(io);
 
         var binary_buffer: [16 * 1024]u8 = undefined;
-        var file_reader = binary_file.reader(binary_buffer[0..]);
+        var file_reader = binary_file.reader(io, binary_buffer[0..]);
 
         const results = try diskScan.readBinaryResults(&file_reader.interface);
 
@@ -189,11 +192,11 @@ pub fn main() !void {
 
         try diskScan.reportResults(results, summary);
     } else if (binary_output) |path| {
-        var binary_file = try std.fs.cwd().createFile(path, .{ .truncate = true, .read = false });
-        defer binary_file.close();
+        var binary_file = try std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true, .read = false });
+        defer binary_file.close(io);
 
         var binary_buffer: [16 * 1024]u8 = undefined;
-        var file_writer = binary_file.writer(binary_buffer[0..]);
+        var file_writer = binary_file.writer(io, binary_buffer[0..]);
 
         try diskScan.runWithBinaryOutput(&file_writer.interface, true);
         try file_writer.end();
@@ -257,9 +260,9 @@ fn printUsage(exe_name: []const u8) !void {
     try stderr.print("       --force: bypass safety checks (e.g., scanning / on macOS)\n", .{});
 }
 
-fn dumpStructLayouts() !void {
+fn dumpStructLayouts(io: std.Io) !void {
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
     defer stdout.flush() catch {};
 
@@ -267,7 +270,7 @@ fn dumpStructLayouts() !void {
     try dumpStruct(stdout, "Worker", WorkerMod.Worker);
     try dumpStruct(stdout, "Worker.Scanner", WorkerMod.Scanner);
     try dumpStruct(stdout, "SysDispatcher.Config", SysDispatcher.Config);
-    try dumpStruct(stdout, "fs.Dir.Iterator", std.fs.Dir.Iterator);
+    try dumpStruct(stdout, "Io.Dir.Iterator", std.Io.Dir.Iterator);
 }
 
 fn dumpStruct(writer: *Writer, comptime name: []const u8, comptime T: type) !void {
@@ -281,23 +284,23 @@ fn dumpStruct(writer: *Writer, comptime name: []const u8, comptime T: type) !voi
                 @as(usize, @alignOf(T)),
             });
 
-            if (struct_info.fields.len > 0) {
+            if (struct_info.field_names.len > 0) {
                 const Row = struct {
                     field: []const u8,
                     type_name: []const u8,
                     size: usize,
                 };
 
-                const capacity = struct_info.fields.len * 2 + 1;
+                const capacity = struct_info.field_names.len * 2 + 1;
                 var rows: [capacity]Row = undefined;
                 var row_count: usize = 0;
 
                 var expected_offset: usize = 0;
 
-                inline for (struct_info.fields) |field| {
-                    const field_offset = @offsetOf(T, field.name);
-                    const field_size = @sizeOf(field.type);
-                    const field_align = @alignOf(field.type);
+                inline for (struct_info.field_names, struct_info.field_types) |field_name, field_type| {
+                    const field_offset = @offsetOf(T, field_name);
+                    const field_size = @sizeOf(field_type);
+                    const field_align = @alignOf(field_type);
 
                     const aligned_offset = std.mem.alignForward(usize, expected_offset, field_align);
                     const padding = aligned_offset - expected_offset;
@@ -311,7 +314,7 @@ fn dumpStruct(writer: *Writer, comptime name: []const u8, comptime T: type) !voi
                         row_count += 1;
                     }
 
-                    const type_name = @typeName(field.type);
+                    const type_name = @typeName(field_type);
                     const max_type_len = 32;
                     const display_type = if (type_name.len > max_type_len)
                         type_name[0 .. max_type_len - 2] ++ ".."
@@ -319,7 +322,7 @@ fn dumpStruct(writer: *Writer, comptime name: []const u8, comptime T: type) !voi
                         type_name;
 
                     rows[row_count] = .{
-                        .field = "." ++ field.name,
+                        .field = "." ++ field_name,
                         .type_name = display_type,
                         .size = field_size,
                     };

--- a/src/scanner_lib.zig
+++ b/src/scanner_lib.zig
@@ -8,6 +8,13 @@ const DiskScan = @import("DiskScan.zig");
 /// Opaque handle to a scanner instance (hides Zig implementation details)
 pub const ScannerHandle = opaque {};
 
+/// A scanner plus the I/O implementation it owns. Unlike the CLI, a shared
+/// library has no `main` to hand us an `Io`, so each handle brings its own.
+const Scanner = struct {
+    threaded: std.Io.Threaded,
+    scan: DiskScan,
+};
+
 /// C-compatible scan options
 pub const CScanOptions = extern struct {
     skip_hidden: bool,
@@ -28,12 +35,14 @@ pub const CScanResults = extern struct {
 export fn wtfs_scanner_create() ?*ScannerHandle {
     const allocator = std.heap.c_allocator;
 
-    const scan = allocator.create(DiskScan) catch return null;
-    scan.* = DiskScan{
+    const scanner = allocator.create(Scanner) catch return null;
+    scanner.threaded = .init(allocator, .{ .stack_size = 32 * 1024 * 1024 });
+    scanner.scan = DiskScan{
         .allocator = allocator,
+        .io = scanner.threaded.io(),
     };
 
-    return @ptrCast(scan);
+    return @ptrCast(scanner);
 }
 
 /// Run a scan on the specified directory
@@ -51,7 +60,8 @@ export fn wtfs_scanner_scan(
     options: *const CScanOptions,
     results: *CScanResults,
 ) bool {
-    const scan: *DiskScan = @ptrCast(@alignCast(handle));
+    const scanner: *Scanner = @ptrCast(@alignCast(handle));
+    const scan = &scanner.scan;
 
     // Configure scan
     scan.skip_hidden = options.skip_hidden;
@@ -59,7 +69,7 @@ export fn wtfs_scanner_scan(
     scan.root = std.mem.span(path);
 
     // Initialize minimal progress tracking (required by gatherPhase)
-    var progress = std.Progress.start(.{
+    var progress = std.Progress.start(scan.io, .{
         .root_name = "wtfs",
         .disable_printing = true,
     });
@@ -93,19 +103,20 @@ export fn wtfs_scanner_write_dump(
     handle: *ScannerHandle,
     path: [*:0]const u8,
 ) bool {
-    const scan: *DiskScan = @ptrCast(@alignCast(handle));
+    const scanner: *Scanner = @ptrCast(@alignCast(handle));
+    const scan = &scanner.scan;
     const file_path = std.mem.span(path);
 
     // Open file for writing
-    var file = std.fs.cwd().createFile(file_path, .{
+    var file = std.Io.Dir.cwd().createFile(scan.io, file_path, .{
         .truncate = true,
         .read = false,
     }) catch return false;
-    defer file.close();
+    defer file.close(scan.io);
 
     // Create buffered writer
     var buffer: [16 * 1024]u8 = undefined;
-    var file_writer = file.writer(&buffer);
+    var file_writer = file.writer(scan.io, &buffer);
 
     // Build results from current scan data
     const results = DiskScan.ScanResults{
@@ -137,7 +148,8 @@ export fn wtfs_scanner_write_dump(
 ///
 /// Returns: Number of large files, or 0 if handle is invalid
 export fn wtfs_scanner_large_file_count(handle: *ScannerHandle) u64 {
-    const scan: *DiskScan = @ptrCast(@alignCast(handle));
+    const scanner: *Scanner = @ptrCast(@alignCast(handle));
+    const scan = &scanner.scan;
     return scan.large_files.len;
 }
 
@@ -158,7 +170,8 @@ export fn wtfs_scanner_get_large_file(
     path_buffer_size: u64,
     size: *u64,
 ) bool {
-    const scan: *DiskScan = @ptrCast(@alignCast(handle));
+    const scanner: *Scanner = @ptrCast(@alignCast(handle));
+    const scan = &scanner.scan;
 
     if (index >= scan.large_files.len) return false;
 
@@ -199,14 +212,16 @@ export fn wtfs_scanner_get_large_file(
 /// Args:
 ///   handle: Scanner instance to destroy
 export fn wtfs_scanner_destroy(handle: *ScannerHandle) void {
-    const scan: *DiskScan = @ptrCast(@alignCast(handle));
+    const scanner: *Scanner = @ptrCast(@alignCast(handle));
+    const scan = &scanner.scan;
     const allocator = scan.allocator;
 
     // Cleanup scan resources
     scan.freeNameBuffers();
     scan.directories.deinit(allocator);
     scan.large_files.deinit(allocator);
+    scanner.threaded.deinit();
 
     // Free the scanner itself
-    allocator.destroy(scan);
+    allocator.destroy(scanner);
 }

--- a/src/test_threading.zig
+++ b/src/test_threading.zig
@@ -3,29 +3,37 @@ const builtin = @import("builtin");
 
 const StartBarrier = struct {
     remaining: std.atomic.Value(usize),
-    event: std.Thread.ResetEvent = .{},
+    event: std.Io.Event = .unset,
 
     fn init(count: usize) StartBarrier {
         return .{ .remaining = std.atomic.Value(usize).init(count) };
     }
 
-    fn wait(self: *StartBarrier) void {
+    fn wait(self: *StartBarrier, io: std.Io) void {
         if (self.remaining.fetchSub(1, .acq_rel) == 1) {
-            self.event.set();
+            self.event.set(io);
         }
-        self.event.wait();
+        self.event.waitUncancelable(io);
     }
 };
 
 pub const ThreadTestGroup = struct {
     start_barrier: StartBarrier,
-    wg: std.Thread.WaitGroup = .{},
+    threaded: std.Io.Threaded,
+    group: std.Io.Group = .init,
 
     pub fn init(thread_count: usize) !ThreadTestGroup {
         if (builtin.single_threaded) {
             return error.ZigSkipTest;
         }
-        return .{ .start_barrier = StartBarrier.init(thread_count) };
+        return .{
+            .start_barrier = StartBarrier.init(thread_count),
+            // Every worker blocks on the start barrier, so they all need to be
+            // running at once: `concurrent`, with room for all of them.
+            .threaded = .init(std.testing.allocator, .{
+                .concurrent_limit = .limited(thread_count),
+            }),
+        };
     }
 
     pub fn spawn(
@@ -41,23 +49,18 @@ pub const ThreadTestGroup = struct {
         };
         const ArgsType = @TypeOf(args);
 
-        self.wg.start();
-
         const Worker = struct {
             const Fn = func;
             const Ret = ReturnType;
             const Args = ArgsType;
 
-            return_value: ?Ret = null,
-
             fn run(
                 mytid: usize,
+                io: std.Io,
                 barrier: *StartBarrier,
-                wg_ptr: *std.Thread.WaitGroup,
                 args_inner: Args,
             ) void {
-                defer wg_ptr.finish();
-                barrier.wait();
+                barrier.wait(io);
                 const tidargs = .{mytid} ++ args_inner;
                 if (@typeInfo(Ret) == .error_union) {
                     (@call(.auto, Fn, tidargs) catch |err| {
@@ -72,17 +75,13 @@ pub const ThreadTestGroup = struct {
             }
         };
 
-        const thread = try std.Thread.spawn(
-            .{},
-            Worker.run,
-            .{
-                tid,
-                &self.start_barrier,
-                &self.wg,
-                args,
-            },
-        );
-        thread.detach();
+        const io = self.threaded.io();
+        try self.group.concurrent(io, Worker.run, .{
+            tid,
+            io,
+            &self.start_barrier,
+            args,
+        });
     }
 
     pub fn spawnMany(
@@ -100,6 +99,7 @@ pub const ThreadTestGroup = struct {
         if (builtin.single_threaded) {
             return;
         }
-        self.wg.wait();
+        self.group.await(self.threaded.io()) catch {};
+        self.threaded.deinit();
     }
 };

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,113 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from wtfs.dump import Directory, DirectoryTotals, WtfsDump
+from wtfs.tui import (
+    ConfirmDeletion,
+    DirectoryTreeView,
+    WtfsApp,
+    deletion_path,
+    outermost_directories,
+)
+
+
+def directory(index, parent_index, path):
+    return Directory(
+        index=index,
+        parent_index=parent_index,
+        name=Path(path).name,
+        total_size=0,
+        total_files=0,
+        total_dirs=0,
+        path=path,
+    )
+
+
+class DeletionPathTests(unittest.TestCase):
+    def test_resolves_directory_beneath_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "one" / "two"
+            target.mkdir(parents=True)
+
+            self.assertEqual(
+                deletion_path(root, directory(2, 1, "./one/two")),
+                target.resolve(),
+            )
+
+    def test_rejects_scan_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ValueError, "scan root"):
+                deletion_path(Path(temporary), directory(0, 0, "."))
+
+    def test_rejects_path_outside_scan_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ValueError, "escapes"):
+                deletion_path(Path(temporary), directory(1, 0, "../outside"))
+
+    def test_rejects_symbolic_links(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "real").mkdir()
+            (root / "link").symlink_to(root / "real", target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "symbolic link"):
+                deletion_path(root, directory(1, 0, "./link"))
+
+
+class OutermostDirectoriesTests(unittest.TestCase):
+    def test_removes_descendants_of_marked_directories(self):
+        directories = [
+            directory(0, 0, "."),
+            directory(1, 0, "./one"),
+            directory(2, 1, "./one/two"),
+            directory(3, 0, "./three"),
+        ]
+
+        self.assertEqual(
+            outermost_directories(
+                [directories[2], directories[3], directories[1]],
+                directories,
+            ),
+            [directories[1], directories[3]],
+        )
+
+
+class DeletionFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_marks_reviews_and_deletes_selected_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "discard-me"
+            target.mkdir()
+            (target / "contents").write_text("gone")
+
+            data = WtfsDump()
+            data.totals = DirectoryTotals(2, 1, 20 * 1024 * 1024)
+            data.directories = [
+                directory(0, 0, "."),
+                directory(1, 0, "./discard-me"),
+            ]
+            data.directories[1].total_size = 20 * 1024 * 1024
+
+            app = WtfsApp(data, root)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                tree = app.query_one(DirectoryTreeView)
+                tree.move_cursor(tree.root.children[0].children[0])
+
+                app.action_mark()
+                self.assertEqual(app.marked, {1})
+
+                app.action_delete_marked()
+                await pilot.pause()
+                self.assertIsInstance(app.screen, ConfirmDeletion)
+
+                await pilot.press("y")
+                await pilot.pause()
+                self.assertFalse(target.exists())
+                self.assertEqual(app.marked, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wtfs/cli.py
+++ b/wtfs/cli.py
@@ -26,6 +26,8 @@ def main():
     parser.add_argument('path', nargs='?', default='.', help='Directory to scan (default: current)')
     parser.add_argument('--save', metavar='FILE', help='Save binary dump to file')
     parser.add_argument('--load', metavar='FILE', help='Load and display existing dump')
+    parser.add_argument('--root', metavar='PATH',
+                       help='Scanned root for a loaded dump (enables TUI deletion)')
     parser.add_argument('--interactive', '-i', action='store_true',
                        help='Launch interactive TUI browser')
     parser.add_argument('--webui', '-w', action='store_true',
@@ -52,7 +54,7 @@ def main():
 
             if args.interactive:
                 from .tui import run_interactive
-                run_interactive(args.load)
+                run_interactive(args.load, root_path=args.root)
             elif args.webui:
                 launch_web_ui(console, data, ".", args.host, args.port)
             else:
@@ -151,4 +153,3 @@ def parse_size(size_str: str) -> int:
 
 if __name__ == '__main__':
     main()
-

--- a/wtfs/tui.py
+++ b/wtfs/tui.py
@@ -1,16 +1,145 @@
 """Interactive TUI for wtfs using Textual."""
 
+import shutil
 from pathlib import Path
-from typing import Optional, List
-from dataclasses import dataclass
-from collections import deque
+from typing import Iterable
 
 from textual.app import App, ComposeResult
-from textual.widgets import Tree
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Footer, Static, Tree
 from textual.widgets.tree import TreeNode
 from textual.binding import Binding
+from rich.markup import escape
 
-from .dump import WtfsDump, Directory, LargeFile, format_size
+from .dump import WtfsDump, Directory, format_size
+
+
+def deletion_path(root_path: Path, directory: Directory) -> Path:
+    """Return a safe absolute deletion path for a directory in a dump."""
+    if directory.index == 0 or directory.path in (None, "."):
+        raise ValueError("the scan root cannot be deleted")
+
+    root = root_path.resolve(strict=True)
+    if not root.is_dir():
+        raise ValueError(f"scan root is not a directory: {root}")
+
+    relative = Path(directory.path)
+    if relative.is_absolute():
+        raise ValueError(f"dump path is unexpectedly absolute: {directory.path}")
+    if ".." in relative.parts:
+        raise ValueError(f"directory escapes the scan root: {directory.path}")
+
+    target = root
+    for part in relative.parts:
+        target /= part
+        if target.is_symlink():
+            raise ValueError(f"refusing to follow a symbolic link: {target}")
+
+    resolved_target = target.resolve(strict=False)
+    if resolved_target == root or not resolved_target.is_relative_to(root):
+        raise ValueError(f"directory escapes the scan root: {directory.path}")
+    return target
+
+
+def outermost_directories(
+    directories: Iterable[Directory],
+    all_directories: list[Directory],
+) -> list[Directory]:
+    """Drop marked descendants when one of their ancestors is also marked."""
+    marked = {directory.index: directory for directory in directories}
+    outermost = []
+    for directory in marked.values():
+        parent_index = directory.parent_index
+        seen = {directory.index}
+        has_marked_ancestor = False
+        while parent_index not in seen and 0 <= parent_index < len(all_directories):
+            if parent_index in marked:
+                has_marked_ancestor = True
+                break
+            if parent_index == 0:
+                break
+            seen.add(parent_index)
+            parent_index = all_directories[parent_index].parent_index
+
+        if not has_marked_ancestor:
+            outermost.append(directory)
+    return sorted(outermost, key=lambda directory: directory.path or "")
+
+
+class ConfirmDeletion(ModalScreen[bool]):
+    """Confirmation dialog for permanent directory deletion."""
+
+    BINDINGS = [
+        Binding("y", "confirm", "Delete", show=False),
+        Binding("n", "cancel", "Cancel", show=False),
+        Binding("escape", "cancel", "Cancel", show=False),
+    ]
+
+    CSS = """
+    ConfirmDeletion {
+        align: center middle;
+    }
+
+    ConfirmDeletion > Vertical {
+        width: 72;
+        max-width: 95%;
+        height: auto;
+        max-height: 90%;
+        padding: 1 2;
+        border: thick $error;
+        background: $panel;
+    }
+
+    ConfirmDeletion .paths {
+        height: auto;
+        max-height: 16;
+        margin: 1 0;
+        overflow-y: auto;
+    }
+
+    ConfirmDeletion Horizontal {
+        width: 100%;
+        height: auto;
+        align-horizontal: right;
+    }
+
+    ConfirmDeletion Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, directories: list[Directory]):
+        super().__init__()
+        self.directories = directories
+
+    def compose(self) -> ComposeResult:
+        total_size = sum(directory.total_size for directory in self.directories)
+        paths = "\n".join(
+            f"  {escape(directory.path or directory.name)}"
+            for directory in self.directories
+        )
+        count = len(self.directories)
+        noun = "directory" if count == 1 else "directories"
+        with Vertical():
+            yield Static(
+                f"[bold red]Permanently delete {count} {noun}?[/bold red]\n"
+                f"Snapshot size: [yellow]{format_size(total_size)}[/yellow]"
+            )
+            yield Static(paths, classes="paths")
+            yield Static("This cannot be undone. Press [bold]y[/bold] to confirm.")
+            with Horizontal():
+                yield Button("Cancel", id="cancel")
+                yield Button("Delete", variant="error", id="delete")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "delete")
 
 
 class DirectoryTreeView(Tree):
@@ -18,9 +147,10 @@ class DirectoryTreeView(Tree):
 
     MIN_SIZE_THRESHOLD = 10 * 1024 * 1024  # 10 MiB
 
-    def __init__(self, data: WtfsDump, **kwargs):
+    def __init__(self, data: WtfsDump, marked: set[int], **kwargs):
         super().__init__("", **kwargs)
         self.data = data
+        self.marked = marked
         self.show_root = False
 
         # Pre-compute children mapping for fast lookup
@@ -85,7 +215,15 @@ class DirectoryTreeView(Tree):
 
         # Use fixed widths for alignment
         # Format: name (40 chars) | size (10 chars right-aligned) | files (right-aligned)
-        return f"[cyan]{name:<40}[/] [yellow]{size_str:>10}[/] [dim]{files:>8,} files[/]"
+        marker = (
+            "[bold red][delete][/bold red] "
+            if directory.index in self.marked
+            else "         "
+        )
+        return (
+            f"{marker}[cyan]{escape(name):<40}[/] "
+            f"[yellow]{size_str:>10}[/] [dim]{files:>8,} files[/]"
+        )
 
 
 class WtfsApp(App):
@@ -116,17 +254,110 @@ class WtfsApp(App):
     """
 
     BINDINGS = [
+        Binding("m", "mark", "Mark/unmark"),
+        Binding("d", "delete_marked", "Delete marked"),
         Binding("q", "quit", "Quit", show=False),
         Binding("ctrl+c", "quit", "Quit", show=False),
     ]
 
-    def __init__(self, data: WtfsDump):
+    def __init__(self, data: WtfsDump, root_path: Path | None = None):
         super().__init__()
         self.data = data
+        self.root_path = root_path.resolve() if root_path is not None else None
+        self.marked: set[int] = set()
 
     def compose(self) -> ComposeResult:
         """Create UI layout."""
-        yield DirectoryTreeView(self.data)
+        yield DirectoryTreeView(self.data, self.marked)
+        yield Footer()
+
+    def action_mark(self) -> None:
+        tree = self.query_one(DirectoryTreeView)
+        node = tree.cursor_node
+        directory = node.data if node is not None else None
+        if not isinstance(directory, Directory):
+            return
+        if self.root_path is None:
+            self.notify(
+                "Deletion is disabled: reopen this dump with --root PATH.",
+                severity="warning",
+            )
+            return
+        if directory.index == 0:
+            self.notify(
+                "The scan root cannot be marked for deletion.",
+                severity="warning",
+            )
+            return
+
+        if directory.index in self.marked:
+            self.marked.remove(directory.index)
+        else:
+            try:
+                deletion_path(self.root_path, directory)
+            except (OSError, ValueError) as error:
+                self.notify(str(error), severity="error")
+                return
+            self.marked.add(directory.index)
+        node.set_label(tree._format_label(directory))
+
+    def action_delete_marked(self) -> None:
+        if not self.marked:
+            self.notify("No directories are marked for deletion.")
+            return
+        if self.root_path is None:
+            self.notify(
+                "Deletion is disabled: reopen with --root PATH.",
+                severity="warning",
+            )
+            return
+
+        directories = outermost_directories(
+            (self.data.directories[index] for index in self.marked),
+            self.data.directories,
+        )
+        self.push_screen(
+            ConfirmDeletion(directories),
+            lambda confirmed: self._delete_marked(directories) if confirmed else None,
+        )
+
+    def _delete_marked(self, directories: list[Directory]) -> None:
+        assert self.root_path is not None
+        deleted = []
+        failures = []
+        for directory in directories:
+            try:
+                target = deletion_path(self.root_path, directory)
+                shutil.rmtree(target)
+            except (OSError, ValueError) as error:
+                failures.append(f"{directory.path}: {error}")
+            else:
+                deleted.append(directory)
+
+        deleted_indexes = {directory.index for directory in deleted}
+        for directory in self.data.directories:
+            parent_index = directory.index
+            seen = set()
+            while parent_index not in seen and 0 <= parent_index < len(self.data.directories):
+                seen.add(parent_index)
+                if parent_index in deleted_indexes:
+                    self.marked.discard(directory.index)
+                    break
+                parent_index = self.data.directories[parent_index].parent_index
+
+        tree = self.query_one(DirectoryTreeView)
+        nodes = [tree.root]
+        for node in nodes:
+            nodes.extend(node.children)
+        for node in nodes:
+            if isinstance(node.data, Directory) and node.data.index in deleted_indexes:
+                node.remove()
+
+        if deleted:
+            count = len(deleted)
+            self.notify(f"Deleted {count} director{'y' if count == 1 else 'ies'}.")
+        if failures:
+            self.notify("\n".join(failures), severity="error", timeout=10)
 
 
 def run_interactive(dump_file: str, root_path: str = None) -> None:
@@ -140,7 +371,7 @@ def run_interactive(dump_file: str, root_path: str = None) -> None:
     if root_path:
         data.root_path = Path(root_path).resolve()
 
-    app = WtfsApp(data)
+    app = WtfsApp(data, Path(root_path) if root_path else None)
     app.run()
 
 
@@ -153,6 +384,10 @@ def main():
         description='Interactive TUI for wtfs scan results',
     )
     parser.add_argument('dump', help='Binary dump file to browse')
+    parser.add_argument(
+        '--root',
+        help='Scanned root directory (required to enable deletion)',
+    )
 
     args = parser.parse_args()
 
@@ -160,9 +395,8 @@ def main():
         print(f"Error: File not found: {args.dump}", file=sys.stderr)
         sys.exit(1)
 
-    run_interactive(args.dump)
+    run_interactive(args.dump, root_path=args.root)
 
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
## What changed

- port the native scanner and build definitions to the Zig 0.17 I/O APIs
- replace the capacity growth mutex/condition with a narrowly scoped atomic growth lock
- add guarded directory marking and confirmed bulk deletion to the Python Textual UI
- require a known scan root for deletion and reject root, escaping, and symbolic-link targets
- collapse marked descendants when an ancestor is already selected
- document the deletion shortcuts and ignore macOS metadata
- add unit and full Textual interaction coverage for the deletion path

## Why

The repository had a coherent but uncommitted Zig 0.17 migration, while the Python TUI lacked the staged deletion workflow. Publishing them together keeps the native scanner, package build, and frontend on one validated state.

## Validation

- `zig fmt --check build.zig src`
- `zig build test`
- `zig build`
- `uv run python -m unittest discover -s tests -v`
- `git diff --check`
