### PR TITLE
Add responsive archive and deletion workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository working agreement
+
+- After completing requested code or documentation work, run the relevant checks,
+  commit all in-scope changes, and push the current working branch. Do this as the
+  normal final checkpoint without waiting for a separate request.
+- Treat commits and pushes as saved-work checkpoints, not as claims that a design
+  is final, released, or beyond revision.
+- Keep unrelated user changes, generated artifacts, credentials, and machine-local
+  files out of the commit. If the intended scope is genuinely ambiguous, confirm it
+  before staging.
+- Do not open or merge a pull request unless the user asks for one or an active
+  higher-priority workflow requires it. If pushing is blocked, report the exact
+  blocker and leave the verified commit intact locally.

--- a/README.md
+++ b/README.md
@@ -174,8 +174,22 @@ uv run wtfs-tui scan.bin
 - `Tab` - Switch between Directories and Large Files tabs
 - `q` - Quit
 - `Ctrl+P` - Command palette
-- `m` - Mark or unmark the selected directory for deletion
+- `m` - Mark or unmark the selected directory
+- `a` - Archive marked directories to a mounted volume or chosen folder
 - `d` - Review and permanently delete marked directories
+
+Deletion runs in the background with live entry and target progress. Independent
+marked directories are removed concurrently. wtfs repairs owner access bits on
+read-only contents when possible; targets that still fail remain marked and get
+a detailed report with the failing path and permission troubleshooting steps.
+
+Archiving creates a timestamped `wtfs-archive-*` directory at the chosen
+destination and mirrors each marked directory's path beneath it. Moves on one
+filesystem use an atomic rename; moves to an external volume stream the copy in
+the background with byte progress, preserve metadata and symbolic links, and
+remove the source only after the copy completes. Each archive includes a
+`manifest.json` recording original paths and outcomes. Mounted volumes such as
+`/Volumes/Lootbox` appear in the destination prompt automatically.
 
 Deletion is enabled automatically after a fresh scan. When opening a saved
 dump directly, provide its original scan root:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,150 @@
+import errno
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from wtfs.archive import (
+    ArchiveItem,
+    archive_item,
+    create_archive_root,
+    write_manifest,
+)
+from wtfs.deletion import DeletionFailure, DeletionResult
+
+
+class ArchiveRootTests(unittest.TestCase):
+    def test_creates_unique_timestamped_roots(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary)
+            now = datetime(2026, 8, 5, 12, 34, 56, tzinfo=timezone.utc)
+
+            first = create_archive_root(destination, now)
+            second = create_archive_root(destination, now)
+
+            self.assertEqual(first.name, "wtfs-archive-2026-08-05_12-34-56+0000")
+            self.assertEqual(second.name, "wtfs-archive-2026-08-05_12-34-56+0000-2")
+
+
+class ArchiveItemTests(unittest.TestCase):
+    def test_same_filesystem_rename_preserves_relative_hierarchy(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            (source / "contents").write_text("kept")
+            archive_root = root / "archive"
+            archive_root.mkdir()
+            item = ArchiveItem(source, Path("Downloads/source"), 4, 2)
+            progress = []
+
+            result = archive_item(
+                item,
+                archive_root,
+                lambda path, byte_count, entry_count: progress.append(
+                    (path, byte_count, entry_count)
+                ),
+            )
+
+            self.assertTrue(result.moved)
+            self.assertEqual(result.method, "rename")
+            self.assertFalse(source.exists())
+            self.assertEqual(
+                (archive_root / "Downloads/source/contents").read_text(),
+                "kept",
+            )
+            self.assertEqual(sum(event[1] for event in progress), 4)
+
+    def test_cross_filesystem_copy_preserves_symlinks_then_removes_source(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "keep").write_text("outside")
+            source = root / "source"
+            source.mkdir()
+            (source / "file").write_bytes(b"archived")
+            (source / "link").symlink_to(outside, target_is_directory=True)
+            archive_root = root / "archive"
+            archive_root.mkdir()
+            item = ArchiveItem(source, Path("source"), 8, 3)
+            progress = []
+
+            with patch(
+                "wtfs.archive.os.rename",
+                side_effect=OSError(errno.EXDEV, "Cross-device link"),
+            ):
+                result = archive_item(
+                    item,
+                    archive_root,
+                    lambda path, byte_count, entry_count: progress.append(
+                        (path, byte_count, entry_count)
+                    ),
+                )
+
+            self.assertTrue(result.moved)
+            self.assertTrue(result.copied)
+            self.assertEqual(result.method, "copy")
+            self.assertFalse(source.exists())
+            self.assertEqual((archive_root / "source/file").read_bytes(), b"archived")
+            self.assertTrue((archive_root / "source/link").is_symlink())
+            self.assertTrue((outside / "keep").exists())
+            self.assertEqual(sum(event[1] for event in progress), 8)
+
+    def test_complete_copy_is_retained_when_source_cleanup_fails(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            (source / "file").write_text("copy survives")
+            archive_root = root / "archive"
+            archive_root.mkdir()
+            item = ArchiveItem(source, Path("source"), 13, 2)
+            failure = DeletionFailure(
+                source,
+                source,
+                "remove directory",
+                PermissionError(errno.EACCES, "Permission denied", source),
+            )
+            failed_cleanup = DeletionResult(source, False, 0, 0, failure)
+
+            with (
+                patch(
+                    "wtfs.archive.os.rename",
+                    side_effect=OSError(errno.EXDEV, "Cross-device link"),
+                ),
+                patch("wtfs.archive.delete_tree", return_value=failed_cleanup),
+            ):
+                result = archive_item(item, archive_root)
+
+            self.assertFalse(result.moved)
+            self.assertTrue(result.copied)
+            self.assertTrue(source.exists())
+            self.assertEqual(
+                (archive_root / "source/file").read_text(),
+                "copy survives",
+            )
+            self.assertEqual(result.failure.phase, "remove copied source")
+
+    def test_manifest_records_original_and_destination_paths(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            archive_root = root / "archive"
+            archive_root.mkdir()
+            item = ArchiveItem(source, Path("source"), 0, 1)
+            result = archive_item(item, archive_root)
+
+            write_manifest(archive_root, root, [result])
+
+            manifest = json.loads((archive_root / "manifest.json").read_text())
+            self.assertEqual(manifest["source_root"], str(root))
+            self.assertEqual(manifest["items"][0]["relative_path"], "source")
+            self.assertTrue(manifest["items"][0]["moved"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,0 +1,78 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from wtfs.deletion import delete_tree
+
+
+class DeleteTreeTests(unittest.TestCase):
+    def test_deletes_tree_and_reports_entry_progress(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target"
+            (target / "nested").mkdir(parents=True)
+            (target / "one").write_text("one")
+            (target / "nested" / "two").write_text("two")
+            progress = []
+
+            result = delete_tree(
+                target,
+                lambda path, count: progress.append((path, count)),
+                progress_interval=1,
+            )
+
+            self.assertTrue(result.deleted)
+            self.assertEqual(result.entries_deleted, 4)
+            self.assertEqual(sum(count for _, count in progress), 4)
+            self.assertFalse(target.exists())
+
+    def test_repairs_owner_access_on_read_only_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target"
+            locked = target / "locked"
+            locked.mkdir(parents=True)
+            (locked / "contents").write_text("gone")
+            os.chmod(locked, 0)
+
+            result = delete_tree(target)
+
+            self.assertTrue(result.deleted)
+            self.assertGreaterEqual(result.permissions_repaired, 1)
+            self.assertFalse(target.exists())
+
+    def test_unlinks_symlink_without_deleting_its_target(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "keep").write_text("still here")
+            target = root / "target"
+            target.mkdir()
+            (target / "link").symlink_to(outside, target_is_directory=True)
+
+            result = delete_tree(target)
+
+            self.assertTrue(result.deleted)
+            self.assertTrue((outside / "keep").exists())
+
+    def test_returns_exact_permission_failure_after_retry(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target"
+            target.mkdir()
+
+            with patch(
+                "wtfs.deletion.os.scandir",
+                side_effect=PermissionError(13, "Permission denied", target),
+            ):
+                result = delete_tree(target)
+
+            self.assertFalse(result.deleted)
+            self.assertIsNotNone(result.failure)
+            self.assertTrue(result.failure.is_permission_error)
+            self.assertEqual(result.failure.operation, "read directory")
+            self.assertEqual(result.failure.path, target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,10 +1,19 @@
 import tempfile
+import threading
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from textual.widgets import Input
+
+from wtfs.deletion import DeletionFailure, DeletionResult, delete_tree
 from wtfs.dump import Directory, DirectoryTotals, WtfsDump
 from wtfs.tui import (
+    ArchiveDestination,
+    ArchiveReport,
     ConfirmDeletion,
+    DeletionReport,
+    DeletionProgress,
     DirectoryTreeView,
     WtfsApp,
     deletion_path,
@@ -104,9 +113,143 @@ class DeletionFlowTests(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(app.screen, ConfirmDeletion)
 
                 await pilot.press("y")
+                await app.workers.wait_for_complete()
                 await pilot.pause()
                 self.assertFalse(target.exists())
                 self.assertEqual(app.marked, set())
+
+    async def test_shows_progress_while_deletion_is_running(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "discard-me"
+            target.mkdir()
+
+            data = WtfsDump()
+            data.totals = DirectoryTotals(2, 0, 20 * 1024 * 1024)
+            data.directories = [
+                directory(0, 0, "."),
+                directory(1, 0, "./discard-me"),
+            ]
+            data.directories[1].total_size = 20 * 1024 * 1024
+
+            started = threading.Event()
+            release = threading.Event()
+
+            def delayed_delete(path, progress):
+                started.set()
+                release.wait(timeout=2)
+                return delete_tree(path, progress)
+
+            app = WtfsApp(data, root)
+            with patch("wtfs.tui.delete_tree", side_effect=delayed_delete):
+                async with app.run_test() as pilot:
+                    await pilot.pause()
+                    tree = app.query_one(DirectoryTreeView)
+                    tree.move_cursor(tree.root.children[0].children[0])
+                    app.action_mark()
+                    app.action_delete_marked()
+                    await pilot.pause()
+                    await pilot.press("y")
+                    await pilot.pause()
+
+                    self.assertTrue(started.wait(timeout=1))
+                    self.assertIsInstance(app.screen, DeletionProgress)
+
+                    release.set()
+                    await app.workers.wait_for_complete()
+                    await pilot.pause()
+                    self.assertFalse(target.exists())
+
+    async def test_permission_failure_stays_marked_and_opens_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "keep-me"
+            target.mkdir()
+
+            data = WtfsDump()
+            data.totals = DirectoryTotals(2, 0, 20 * 1024 * 1024)
+            data.directories = [
+                directory(0, 0, "."),
+                directory(1, 0, "./keep-me"),
+            ]
+            data.directories[1].total_size = 20 * 1024 * 1024
+            failure = DeletionFailure(
+                target,
+                target / "locked",
+                "remove file",
+                PermissionError(13, "Permission denied", target / "locked"),
+            )
+            failed_result = DeletionResult(target, False, 0, 1, failure)
+
+            app = WtfsApp(data, root)
+            with patch("wtfs.tui.delete_tree", return_value=failed_result):
+                async with app.run_test() as pilot:
+                    await pilot.pause()
+                    tree = app.query_one(DirectoryTreeView)
+                    tree.move_cursor(tree.root.children[0].children[0])
+                    app.action_mark()
+                    app.action_delete_marked()
+                    await pilot.pause()
+                    await pilot.press("y")
+                    await app.workers.wait_for_complete()
+                    await pilot.pause()
+
+                    self.assertIsInstance(app.screen, DeletionReport)
+                    self.assertEqual(app.marked, {1})
+                    self.assertTrue(target.exists())
+                    report = DeletionReport._failure_text(failure)
+                    self.assertIn("Permission denied", report)
+                    self.assertIn("Full Disk Access", report)
+
+
+class ArchiveFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_prompts_for_destination_and_archives_mirrored_path(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "scanned"
+            target = root / "Downloads" / "later"
+            target.mkdir(parents=True)
+            (target / "contents").write_text("saved")
+            destination = Path(temporary) / "destination"
+            destination.mkdir()
+
+            data = WtfsDump()
+            data.totals = DirectoryTotals(3, 1, 20 * 1024 * 1024)
+            data.directories = [
+                directory(0, 0, "."),
+                directory(1, 0, "./Downloads"),
+                directory(2, 1, "./Downloads/later"),
+            ]
+            data.directories[1].total_size = 20 * 1024 * 1024
+            data.directories[2].total_size = 20 * 1024 * 1024
+
+            app = WtfsApp(data, root)
+            with patch("wtfs.tui.mounted_volumes", return_value=[]):
+                async with app.run_test() as pilot:
+                    await pilot.pause()
+                    tree = app.query_one(DirectoryTreeView)
+                    downloads = tree.root.children[0].children[0]
+                    downloads.expand()
+                    await pilot.pause()
+                    tree.move_cursor(downloads.children[0])
+                    app.action_mark()
+                    app.action_archive_marked()
+                    await pilot.pause()
+
+                    self.assertIsInstance(app.screen, ArchiveDestination)
+                    app.screen.query_one("#archive-path", Input).value = str(destination)
+                    await pilot.click("#archive")
+                    await pilot.pause()
+                    await app.workers.wait_for_complete()
+                    await pilot.pause()
+
+                    self.assertIsInstance(app.screen, ArchiveReport)
+                    archives = list(destination.glob("wtfs-archive-*"))
+                    self.assertEqual(len(archives), 1)
+                    archived = archives[0] / "Downloads" / "later"
+                    self.assertEqual((archived / "contents").read_text(), "saved")
+                    self.assertTrue((archives[0] / "manifest.json").exists())
+                    self.assertFalse(target.exists())
+                    self.assertEqual(app.marked, set())
 
 
 if __name__ == "__main__":

--- a/wtfs/archive.py
+++ b/wtfs/archive.py
@@ -1,0 +1,303 @@
+"""Safe, progress-reporting directory archiving."""
+
+import errno
+import json
+import os
+import shutil
+import stat
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+from .deletion import delete_tree
+
+
+ArchiveProgress = Callable[[Path, int, int], None]
+
+
+@dataclass(frozen=True)
+class ArchiveItem:
+    source: Path
+    relative_path: Path
+    expected_bytes: int
+    expected_entries: int
+
+
+@dataclass(frozen=True)
+class ArchiveFailure:
+    phase: str
+    path: Path
+    error: OSError
+
+    @property
+    def is_permission_error(self) -> bool:
+        return isinstance(self.error, PermissionError) or self.error.errno in {
+            errno.EACCES,
+            errno.EPERM,
+        }
+
+
+@dataclass(frozen=True)
+class ArchiveResult:
+    item: ArchiveItem
+    destination: Path
+    moved: bool
+    copied: bool
+    bytes_copied: int
+    entries_copied: int
+    method: str
+    failure: ArchiveFailure | None = None
+
+
+def mounted_volumes() -> list[Path]:
+    """Return currently mounted macOS-style data volumes."""
+    volumes_root = Path("/Volumes")
+    try:
+        volumes = [path for path in volumes_root.iterdir() if path.is_dir()]
+    except OSError:
+        return []
+    return sorted(volumes, key=lambda path: path.name.casefold())
+
+
+def create_archive_root(
+    destination: Path,
+    now: datetime | None = None,
+) -> Path:
+    """Create and return a unique timestamped archive root."""
+    destination = Path(destination).expanduser().resolve(strict=True)
+    if not destination.is_dir():
+        raise NotADirectoryError(destination)
+
+    timestamp = (now or datetime.now().astimezone()).strftime("%Y-%m-%d_%H-%M-%S%z")
+    base_name = f"wtfs-archive-{timestamp}"
+    for suffix in range(1000):
+        name = base_name if suffix == 0 else f"{base_name}-{suffix + 1}"
+        archive_root = destination / name
+        try:
+            archive_root.mkdir(mode=0o755)
+        except FileExistsError:
+            continue
+        return archive_root
+    raise FileExistsError(f"could not choose a unique archive name in {destination}")
+
+
+def _add_owner_read_access(path: Path) -> bool:
+    try:
+        details = path.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(details.st_mode):
+        return False
+    mode = stat.S_IMODE(details.st_mode) | stat.S_IRUSR
+    if stat.S_ISDIR(details.st_mode):
+        mode |= stat.S_IXUSR
+    try:
+        os.chmod(path, mode, follow_symlinks=False)
+    except OSError:
+        return False
+    return True
+
+
+def _copy_regular_file(
+    source: str,
+    destination: str,
+    progress: ArchiveProgress | None,
+) -> str:
+    source_path = Path(source)
+    destination_path = Path(destination)
+    temporary = destination_path.with_name(
+        f".{destination_path.name}.wtfs-partial-{os.getpid()}"
+    )
+    copied = 0
+
+    def copy_contents() -> None:
+        nonlocal copied
+        with source_path.open("rb", buffering=0) as source_file:
+            with temporary.open("xb", buffering=0) as destination_file:
+                buffer = bytearray(8 * 1024 * 1024)
+                view = memoryview(buffer)
+                while count := source_file.readinto(buffer):
+                    destination_file.write(view[:count])
+                    copied += count
+                    if progress is not None:
+                        progress(source_path, count, 0)
+
+    try:
+        try:
+            copy_contents()
+        except PermissionError:
+            if not _add_owner_read_access(source_path):
+                raise
+            copy_contents()
+        os.replace(temporary, destination_path)
+        shutil.copystat(source_path, destination_path, follow_symlinks=False)
+        if progress is not None:
+            progress(source_path, 0, 1)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return destination
+
+
+def archive_item(
+    item: ArchiveItem,
+    archive_root: Path,
+    progress: ArchiveProgress | None = None,
+) -> ArchiveResult:
+    """Move one directory into an archive, copying first across filesystems."""
+    source = item.source
+    destination = archive_root / item.relative_path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.exists() or destination.is_symlink():
+        error = FileExistsError(errno.EEXIST, "archive destination exists", destination)
+        return ArchiveResult(
+            item,
+            destination,
+            False,
+            False,
+            0,
+            0,
+            "none",
+            ArchiveFailure("prepare destination", destination, error),
+        )
+
+    try:
+        os.rename(source, destination)
+    except OSError as rename_error:
+        if rename_error.errno != errno.EXDEV:
+            return ArchiveResult(
+                item,
+                destination,
+                False,
+                False,
+                0,
+                0,
+                "rename",
+                ArchiveFailure("move", source, rename_error),
+            )
+    else:
+        if progress is not None:
+            progress(source, item.expected_bytes, item.expected_entries)
+        return ArchiveResult(
+            item,
+            destination,
+            True,
+            False,
+            item.expected_bytes,
+            item.expected_entries,
+            "rename",
+        )
+
+    copied_bytes = 0
+    copied_entries = 0
+
+    def record_progress(path: Path, byte_count: int, entry_count: int) -> None:
+        nonlocal copied_bytes, copied_entries
+        copied_bytes += byte_count
+        copied_entries += entry_count
+        if progress is not None:
+            progress(path, byte_count, entry_count)
+
+    try:
+        shutil.copytree(
+            source,
+            destination,
+            symlinks=True,
+            copy_function=lambda src, dst: _copy_regular_file(
+                src,
+                dst,
+                record_progress,
+            ),
+        )
+    except (OSError, shutil.Error) as copy_error:
+        if isinstance(copy_error, shutil.Error):
+            recorded_errors = copy_error.args[0] if copy_error.args else []
+            first_error = recorded_errors[0] if recorded_errors else None
+            if first_error is not None:
+                failed_source, _, reason = first_error
+                if isinstance(reason, OSError):
+                    error = reason
+                elif "Permission denied" in str(reason):
+                    error = PermissionError(errno.EACCES, str(reason), failed_source)
+                else:
+                    error = OSError(str(reason))
+            else:
+                error = OSError(str(copy_error))
+        else:
+            error = copy_error
+        return ArchiveResult(
+            item,
+            destination,
+            False,
+            False,
+            copied_bytes,
+            copied_entries,
+            "copy",
+            ArchiveFailure("copy", source, error),
+        )
+
+    deletion = delete_tree(source)
+    if not deletion.deleted:
+        failure = deletion.failure
+        error = failure.error if failure is not None else OSError("source cleanup failed")
+        path = failure.path if failure is not None else source
+        return ArchiveResult(
+            item,
+            destination,
+            False,
+            True,
+            copied_bytes,
+            copied_entries,
+            "copy",
+            ArchiveFailure("remove copied source", path, error),
+        )
+
+    return ArchiveResult(
+        item,
+        destination,
+        True,
+        True,
+        copied_bytes,
+        copied_entries,
+        "copy",
+    )
+
+
+def write_manifest(
+    archive_root: Path,
+    source_root: Path,
+    results: list[ArchiveResult],
+) -> None:
+    """Write a human-readable record of archive sources and outcomes."""
+    manifest = {
+        "created_at": datetime.now().astimezone().isoformat(),
+        "source_root": str(source_root),
+        "archive_root": str(archive_root),
+        "items": [
+            {
+                "source": str(result.item.source),
+                "relative_path": str(result.item.relative_path),
+                "destination": str(result.destination),
+                "moved": result.moved,
+                "copied": result.copied,
+                "bytes": result.bytes_copied,
+                "entries": result.entries_copied,
+                "method": result.method,
+                "failure": (
+                    {
+                        "phase": result.failure.phase,
+                        "path": str(result.failure.path),
+                        "error": str(result.failure.error),
+                    }
+                    if result.failure is not None
+                    else None
+                ),
+            }
+            for result in results
+        ],
+    }
+    temporary = archive_root / ".manifest.json.wtfs-partial"
+    temporary.write_text(json.dumps(manifest, indent=2) + "\n")
+    os.replace(temporary, archive_root / "manifest.json")

--- a/wtfs/deletion.py
+++ b/wtfs/deletion.py
@@ -1,0 +1,214 @@
+"""Filesystem deletion with progress and conservative permission repair."""
+
+import errno
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, TypeVar
+
+
+T = TypeVar("T")
+ProgressCallback = Callable[[Path, int], None]
+
+
+@dataclass(frozen=True)
+class DeletionFailure:
+    """A filesystem operation that prevented a tree from being deleted."""
+
+    target: Path
+    path: Path
+    operation: str
+    error: OSError
+
+    @property
+    def is_permission_error(self) -> bool:
+        return isinstance(self.error, PermissionError) or self.error.errno in {
+            errno.EACCES,
+            errno.EPERM,
+        }
+
+
+@dataclass(frozen=True)
+class DeletionResult:
+    """Result of deleting one selected directory tree."""
+
+    target: Path
+    deleted: bool
+    entries_deleted: int
+    permissions_repaired: int
+    failure: DeletionFailure | None = None
+
+
+class _OperationFailed(Exception):
+    def __init__(self, path: Path, operation: str, error: OSError):
+        super().__init__(str(error))
+        self.path = path
+        self.operation = operation
+        self.error = error
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _make_owner_accessible(path: Path) -> bool:
+    """Add only owner access bits, without following symbolic links."""
+    try:
+        details = path.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(details.st_mode):
+        return False
+
+    mode = stat.S_IMODE(details.st_mode) | stat.S_IRUSR | stat.S_IWUSR
+    if stat.S_ISDIR(details.st_mode):
+        mode |= stat.S_IXUSR
+    try:
+        os.chmod(path, mode, follow_symlinks=False)
+    except OSError:
+        return False
+    return True
+
+
+def _run_with_permission_retry(
+    operation: str,
+    path: Path,
+    target: Path,
+    function: Callable[[], T],
+) -> tuple[T, int]:
+    """Run an operation, repairing owner bits inside the target on permission failure."""
+    try:
+        return function(), 0
+    except PermissionError:
+        repaired = 0
+        candidates = [path]
+        if path != target and _is_within(path.parent, target):
+            candidates.append(path.parent)
+        for candidate in candidates:
+            repaired += int(_make_owner_accessible(candidate))
+
+        try:
+            return function(), repaired
+        except OSError as error:
+            raise _OperationFailed(path, operation, error) from error
+    except OSError as error:
+        raise _OperationFailed(path, operation, error) from error
+
+
+def delete_tree(
+    target: Path,
+    progress: ProgressCallback | None = None,
+    progress_interval: int = 512,
+) -> DeletionResult:
+    """Delete a directory tree without following links, reporting incremental progress."""
+    target = Path(target)
+    entries_deleted = 0
+    reported_entries = 0
+    permissions_repaired = 0
+
+    def report(force: bool = False) -> None:
+        nonlocal reported_entries
+        delta = entries_deleted - reported_entries
+        if progress is not None and (force or delta >= progress_interval):
+            progress(target, delta)
+            reported_entries = entries_deleted
+
+    try:
+        try:
+            target_details = target.lstat()
+        except FileNotFoundError:
+            return DeletionResult(target, True, 0, 0)
+        except OSError as error:
+            raise _OperationFailed(target, "inspect target", error) from error
+        if stat.S_ISLNK(target_details.st_mode) or not stat.S_ISDIR(
+            target_details.st_mode
+        ):
+            error = OSError(errno.EINVAL, "target is not a real directory", target)
+            raise _OperationFailed(target, "validate", error)
+
+        stack: list[tuple[Path, bool]] = [(target, False)]
+        while stack:
+            path, visited = stack.pop()
+            if visited:
+                _, repaired = _run_with_permission_retry(
+                    "remove directory",
+                    path,
+                    target,
+                    lambda path=path: os.rmdir(path),
+                )
+                permissions_repaired += repaired
+                entries_deleted += 1
+                report()
+                continue
+
+            try:
+                path_details = path.lstat()
+            except OSError as error:
+                raise _OperationFailed(path, "inspect directory", error) from error
+            if stat.S_ISLNK(path_details.st_mode) or not stat.S_ISDIR(
+                path_details.st_mode
+            ):
+                error = OSError(
+                    errno.ELOOP,
+                    "directory changed into a symbolic link during deletion",
+                    path,
+                )
+                raise _OperationFailed(path, "validate directory", error)
+
+            entries, repaired = _run_with_permission_retry(
+                "read directory",
+                path,
+                target,
+                lambda path=path: list(os.scandir(path)),
+            )
+            permissions_repaired += repaired
+            stack.append((path, True))
+
+            for entry in entries:
+                child = Path(entry.path)
+                is_directory, repaired = _run_with_permission_retry(
+                    "inspect entry",
+                    child,
+                    target,
+                    lambda entry=entry: entry.is_dir(follow_symlinks=False),
+                )
+                permissions_repaired += repaired
+                if is_directory:
+                    stack.append((child, False))
+                else:
+                    _, repaired = _run_with_permission_retry(
+                        "remove file",
+                        child,
+                        target,
+                        lambda child=child: os.unlink(child),
+                    )
+                    permissions_repaired += repaired
+                    entries_deleted += 1
+                    report()
+
+        report(force=True)
+        return DeletionResult(
+            target,
+            True,
+            entries_deleted,
+            permissions_repaired,
+        )
+    except _OperationFailed as failure:
+        report(force=True)
+        return DeletionResult(
+            target,
+            False,
+            entries_deleted,
+            permissions_repaired,
+            DeletionFailure(
+                target,
+                failure.path,
+                failure.operation,
+                failure.error,
+            ),
+        )

--- a/wtfs/tui.py
+++ b/wtfs/tui.py
@@ -1,17 +1,39 @@
 """Interactive TUI for wtfs using Textual."""
 
-import shutil
+import os
+import shlex
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Footer, Static, Tree
+from textual.widgets import (
+    Button,
+    Footer,
+    Input,
+    LoadingIndicator,
+    ProgressBar,
+    Select,
+    Static,
+    Tree,
+)
 from textual.widgets.tree import TreeNode
 from textual.binding import Binding
 from rich.markup import escape
 
+from .archive import (
+    ArchiveFailure,
+    ArchiveItem,
+    ArchiveResult,
+    archive_item,
+    create_archive_root,
+    mounted_volumes,
+    write_manifest,
+)
+from .deletion import DeletionFailure, DeletionResult, delete_tree
 from .dump import WtfsDump, Directory, format_size
 
 
@@ -142,6 +164,440 @@ class ConfirmDeletion(ModalScreen[bool]):
         self.dismiss(event.button.id == "delete")
 
 
+class DeletionProgress(ModalScreen[None]):
+    """Non-dismissible progress display while filesystem deletion is active."""
+
+    CSS = """
+    DeletionProgress {
+        align: center middle;
+    }
+
+    DeletionProgress > Vertical {
+        width: 72;
+        max-width: 95%;
+        height: auto;
+        padding: 1 2;
+        border: thick $warning;
+        background: $panel;
+    }
+
+    DeletionProgress LoadingIndicator {
+        height: 3;
+    }
+
+    DeletionProgress ProgressBar {
+        margin: 1 0;
+    }
+    """
+
+    def __init__(self, directories: list[Directory]):
+        super().__init__()
+        self.directories = directories
+        self.expected_entries = sum(
+            max(1, directory.total_files + directory.total_dirs)
+            for directory in directories
+        )
+        self.entries_deleted = 0
+        self.targets_finished = 0
+
+    def compose(self) -> ComposeResult:
+        count = len(self.directories)
+        yield Vertical(
+            Static(
+                f"[bold]Deleting {count} "
+                f"director{'y' if count == 1 else 'ies'}…[/bold]"
+            ),
+            LoadingIndicator(),
+            ProgressBar(total=self.expected_entries, show_eta=False),
+            Static("Starting…", id="deletion-status"),
+        )
+
+    def advance_entries(self, target: Path, count: int) -> None:
+        """Record deleted filesystem entries on the UI thread."""
+        self.entries_deleted += count
+        progress = self.query_one(ProgressBar)
+        if self.entries_deleted > self.expected_entries:
+            progress.update(total=self.entries_deleted)
+        progress.update(progress=self.entries_deleted)
+        self.query_one("#deletion-status", Static).update(
+            f"Removed {self.entries_deleted:,} entries · {escape(str(target))}"
+        )
+
+    def target_finished(self, target: Path) -> None:
+        """Record completion of one independently selected target."""
+        self.targets_finished += 1
+        self.query_one("#deletion-status", Static).update(
+            f"Finished {self.targets_finished}/{len(self.directories)} targets · "
+            f"{self.entries_deleted:,} entries removed · {escape(str(target))}"
+        )
+
+
+@dataclass(frozen=True)
+class DirectoryDeletionResult:
+    directory: Directory
+    result: DeletionResult
+
+
+class DeletionReport(ModalScreen[None]):
+    """Durable summary explaining partial deletion failures and next steps."""
+
+    BINDINGS = [
+        Binding("enter", "close", "Close", show=False),
+        Binding("escape", "close", "Close", show=False),
+    ]
+
+    CSS = """
+    DeletionReport {
+        align: center middle;
+    }
+
+    DeletionReport > Vertical {
+        width: 84;
+        max-width: 96%;
+        height: auto;
+        max-height: 92%;
+        padding: 1 2;
+        border: thick $error;
+        background: $panel;
+    }
+
+    DeletionReport .details {
+        height: auto;
+        max-height: 24;
+        margin: 1 0;
+        overflow-y: auto;
+    }
+
+    DeletionReport Button {
+        align-horizontal: right;
+    }
+    """
+
+    def __init__(self, results: list[DirectoryDeletionResult]):
+        super().__init__()
+        self.results = results
+
+    @staticmethod
+    def _failure_text(failure: DeletionFailure) -> str:
+        operation = escape(failure.operation)
+        path = escape(str(failure.path))
+        message = escape(str(failure.error))
+        lines = [f"[bold red]{operation} failed[/bold red]: {path}", f"  {message}"]
+        if failure.is_permission_error:
+            inspect_command = escape(f"ls -ldeO {shlex.quote(str(failure.path))}")
+            lines.extend(
+                [
+                    "  wtfs already retried after adding owner access bits inside the target.",
+                    f"  Inspect ownership, ACLs, and flags: [bold]{inspect_command}[/bold]",
+                    "  Fix the owning directory's permissions or ACLs. On macOS, protected",
+                    "  locations may require Full Disk Access for the terminal application.",
+                ]
+            )
+        return "\n".join(lines)
+
+    def compose(self) -> ComposeResult:
+        succeeded = sum(result.result.deleted for result in self.results)
+        failed = len(self.results) - succeeded
+        details = "\n\n".join(
+            self._failure_text(result.result.failure)
+            for result in self.results
+            if result.result.failure is not None
+        )
+        with Vertical():
+            yield Static(
+                f"[bold red]Deletion incomplete[/bold red]\n"
+                f"Deleted {succeeded} targets; {failed} failed."
+            )
+            yield Static(details, classes="details")
+            yield Static(
+                "Failed targets remain marked. Correct the problem, then press "
+                "[bold]d[/bold] to retry. Some contents may already be gone."
+            )
+            yield Button("Close", variant="primary", id="close")
+
+    def action_close(self) -> None:
+        self.dismiss()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss()
+
+
+class ArchiveDestination(ModalScreen[Path | None]):
+    """Choose a mounted volume or existing directory for a new archive."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    CSS = """
+    ArchiveDestination {
+        align: center middle;
+    }
+
+    ArchiveDestination > Vertical {
+        width: 76;
+        max-width: 95%;
+        height: auto;
+        padding: 1 2;
+        border: thick $accent;
+        background: $panel;
+    }
+
+    ArchiveDestination Select, ArchiveDestination Input {
+        margin: 1 0;
+    }
+
+    ArchiveDestination .error {
+        color: $error;
+        height: auto;
+    }
+
+    ArchiveDestination Horizontal {
+        width: 100%;
+        height: auto;
+        align-horizontal: right;
+    }
+
+    ArchiveDestination Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, volumes: list[Path]):
+        super().__init__()
+        self.volumes = volumes
+
+    def compose(self) -> ComposeResult:
+        default = str(self.volumes[0]) if self.volumes else str(Path.home())
+        options = [(f"{volume.name} — {volume}", str(volume)) for volume in self.volumes]
+        with Vertical():
+            yield Static(
+                "[bold]Archive marked directories[/bold]\n"
+                "Choose a mounted volume or enter any existing destination folder. "
+                "wtfs will create a timestamped archive root there."
+            )
+            if options:
+                yield Select(
+                    options,
+                    value=default,
+                    allow_blank=False,
+                    id="archive-volume",
+                )
+            yield Input(default, placeholder="Destination folder", id="archive-path")
+            yield Static("", id="archive-destination-error", classes="error")
+            with Horizontal():
+                yield Button("Cancel", id="cancel")
+                yield Button("Archive", variant="primary", id="archive")
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "archive-volume" and isinstance(event.value, str):
+            self.query_one("#archive-path", Input).value = event.value
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+
+        raw_path = self.query_one("#archive-path", Input).value.strip()
+        destination = Path(raw_path).expanduser()
+        error = self.query_one("#archive-destination-error", Static)
+        if not raw_path:
+            error.update("Enter a destination folder.")
+        elif not destination.exists():
+            error.update(f"Destination does not exist: {escape(str(destination))}")
+        elif not destination.is_dir():
+            error.update(f"Destination is not a directory: {escape(str(destination))}")
+        else:
+            self.dismiss(destination.resolve())
+
+
+class ArchiveProgressScreen(ModalScreen[None]):
+    """Non-dismissible byte and target progress for an archive operation."""
+
+    CSS = """
+    ArchiveProgressScreen {
+        align: center middle;
+    }
+
+    ArchiveProgressScreen > Vertical {
+        width: 76;
+        max-width: 95%;
+        height: auto;
+        padding: 1 2;
+        border: thick $accent;
+        background: $panel;
+    }
+
+    ArchiveProgressScreen LoadingIndicator {
+        height: 3;
+    }
+
+    ArchiveProgressScreen ProgressBar {
+        margin: 1 0;
+    }
+    """
+
+    def __init__(self, directories: list[Directory], destination: Path):
+        super().__init__()
+        self.directories = directories
+        self.destination = destination
+        self.expected_bytes = max(1, sum(item.total_size for item in directories))
+        self.bytes_copied = 0
+        self.entries_copied = 0
+        self.targets_finished = 0
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(
+                f"[bold]Archiving {len(self.directories)} marked "
+                f"director{'y' if len(self.directories) == 1 else 'ies'}…[/bold]"
+            ),
+            LoadingIndicator(),
+            ProgressBar(total=self.expected_bytes, show_eta=False),
+            Static(
+                f"Preparing archive in {escape(str(self.destination))}",
+                id="archive-status",
+            ),
+        )
+
+    def set_archive_root(self, archive_root: Path) -> None:
+        self.query_one("#archive-status", Static).update(
+            f"Archive root: {escape(str(archive_root))}"
+        )
+
+    def advance(self, path: Path, byte_count: int, entry_count: int) -> None:
+        self.bytes_copied += byte_count
+        self.entries_copied += entry_count
+        progress = self.query_one(ProgressBar)
+        if self.bytes_copied > self.expected_bytes:
+            progress.update(total=self.bytes_copied)
+        progress.update(progress=self.bytes_copied)
+        self.query_one("#archive-status", Static).update(
+            f"{format_size(self.bytes_copied)} · {self.entries_copied:,} files · "
+            f"{escape(str(path))}"
+        )
+
+    def target_finished(self, path: Path) -> None:
+        self.targets_finished += 1
+        self.query_one("#archive-status", Static).update(
+            f"Finished {self.targets_finished}/{len(self.directories)} targets · "
+            f"{format_size(self.bytes_copied)} · {escape(str(path))}"
+        )
+
+
+@dataclass(frozen=True)
+class DirectoryArchiveResult:
+    directory: Directory
+    result: ArchiveResult
+
+
+@dataclass(frozen=True)
+class ArchiveBatchResult:
+    requested_destination: Path
+    archive_root: Path | None
+    results: list[DirectoryArchiveResult]
+    failure: ArchiveFailure | None = None
+
+
+class ArchiveReport(ModalScreen[None]):
+    """Persistent archive destination and partial-failure report."""
+
+    BINDINGS = [
+        Binding("enter", "close", "Close", show=False),
+        Binding("escape", "close", "Close", show=False),
+    ]
+
+    CSS = """
+    ArchiveReport {
+        align: center middle;
+    }
+
+    ArchiveReport > Vertical {
+        width: 86;
+        max-width: 96%;
+        height: auto;
+        max-height: 92%;
+        padding: 1 2;
+        border: thick $accent;
+        background: $panel;
+    }
+
+    ArchiveReport .details {
+        height: auto;
+        max-height: 25;
+        margin: 1 0;
+        overflow-y: auto;
+    }
+    """
+
+    def __init__(self, batch: ArchiveBatchResult):
+        super().__init__()
+        self.batch = batch
+
+    @staticmethod
+    def _failure_text(failure: ArchiveFailure) -> str:
+        lines = [
+            f"[bold red]{escape(failure.phase)} failed[/bold red]: "
+            f"{escape(str(failure.path))}",
+            f"  {escape(str(failure.error))}",
+        ]
+        if failure.is_permission_error:
+            command = escape(f"ls -ldeO {shlex.quote(str(failure.path))}")
+            lines.extend(
+                [
+                    f"  Inspect ownership, ACLs, and flags: [bold]{command}[/bold]",
+                    "  Fix access or grant the terminal Full Disk Access on macOS, then retry.",
+                ]
+            )
+        return "\n".join(lines)
+
+    def compose(self) -> ComposeResult:
+        moved = sum(item.result.moved for item in self.batch.results)
+        failed_results = [item for item in self.batch.results if not item.result.moved]
+        root = self.batch.archive_root or self.batch.requested_destination
+        detail_parts = []
+        if self.batch.failure is not None:
+            detail_parts.append(self._failure_text(self.batch.failure))
+        for item in failed_results:
+            if item.result.failure is not None:
+                detail_parts.append(self._failure_text(item.result.failure))
+                if item.result.copied:
+                    detail_parts.append(
+                        "  A complete copy exists at "
+                        f"{escape(str(item.result.destination))}, but the source remains."
+                    )
+            if not item.result.copied and item.result.destination.exists():
+                detail_parts.append(
+                    f"Partial destination retained: {escape(str(item.result.destination))}"
+                )
+
+        with Vertical():
+            complete = not failed_results and self.batch.failure is None
+            heading = "Archive complete" if complete else "Archive incomplete"
+            heading_style = "bold green" if complete else "bold red"
+            yield Static(
+                f"[{heading_style}]{heading}[/]\n"
+                f"Moved {moved}/{len(self.batch.results)} targets.\n"
+                f"Archive root: [bold]{escape(str(root))}[/bold]"
+            )
+            if detail_parts:
+                yield Static("\n\n".join(detail_parts), classes="details")
+                yield Static(
+                    "Failed sources remain marked. Fix the problem and press "
+                    "[bold]a[/bold] to create a new archive attempt."
+                )
+            elif self.batch.archive_root is not None:
+                yield Static("A manifest.json file records the original paths and outcomes.")
+            yield Button("Close", variant="primary", id="close")
+
+    def action_close(self) -> None:
+        self.dismiss()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss()
+
+
 class DirectoryTreeView(Tree):
     """Hierarchical tree view of directories."""
 
@@ -216,7 +672,7 @@ class DirectoryTreeView(Tree):
         # Use fixed widths for alignment
         # Format: name (40 chars) | size (10 chars right-aligned) | files (right-aligned)
         marker = (
-            "[bold red][delete][/bold red] "
+            "[bold yellow][marked][/bold yellow] "
             if directory.index in self.marked
             else "         "
         )
@@ -255,6 +711,7 @@ class WtfsApp(App):
 
     BINDINGS = [
         Binding("m", "mark", "Mark/unmark"),
+        Binding("a", "archive_marked", "Archive marked"),
         Binding("d", "delete_marked", "Delete marked"),
         Binding("q", "quit", "Quit", show=False),
         Binding("ctrl+c", "quit", "Quit", show=False),
@@ -301,6 +758,30 @@ class WtfsApp(App):
             self.marked.add(directory.index)
         node.set_label(tree._format_label(directory))
 
+    def action_archive_marked(self) -> None:
+        if not self.marked:
+            self.notify("No directories are marked for archiving.")
+            return
+        if self.root_path is None:
+            self.notify(
+                "Archiving is disabled: reopen with --root PATH.",
+                severity="warning",
+            )
+            return
+
+        directories = outermost_directories(
+            (self.data.directories[index] for index in self.marked),
+            self.data.directories,
+        )
+        self.push_screen(
+            ArchiveDestination(mounted_volumes()),
+            lambda destination: (
+                self._start_archive(directories, destination)
+                if destination is not None
+                else None
+            ),
+        )
+
     def action_delete_marked(self) -> None:
         if not self.marked:
             self.notify("No directories are marked for deletion.")
@@ -318,29 +799,139 @@ class WtfsApp(App):
         )
         self.push_screen(
             ConfirmDeletion(directories),
-            lambda confirmed: self._delete_marked(directories) if confirmed else None,
+            lambda confirmed: self._start_deletion(directories) if confirmed else None,
         )
 
-    def _delete_marked(self, directories: list[Directory]) -> None:
-        assert self.root_path is not None
-        deleted = []
-        failures = []
-        for directory in directories:
-            try:
-                target = deletion_path(self.root_path, directory)
-                shutil.rmtree(target)
-            except (OSError, ValueError) as error:
-                failures.append(f"{directory.path}: {error}")
-            else:
-                deleted.append(directory)
+    def _start_deletion(self, directories: list[Directory]) -> None:
+        progress = DeletionProgress(directories)
+        self.push_screen(progress)
+        self.call_after_refresh(self._launch_deletion_worker, directories, progress)
 
-        deleted_indexes = {directory.index for directory in deleted}
+    def _launch_deletion_worker(
+        self,
+        directories: list[Directory],
+        progress: DeletionProgress,
+    ) -> None:
+        self.run_worker(
+            lambda: self._delete_in_background(directories, progress),
+            name="delete-marked-directories",
+            group="deletion",
+            exclusive=True,
+            thread=True,
+        )
+
+    def _delete_in_background(
+        self,
+        directories: list[Directory],
+        progress: DeletionProgress,
+    ) -> None:
+        assert self.root_path is not None
+        results: list[DirectoryDeletionResult] = []
+        pending = {}
+
+        worker_count = min(4, len(directories), os.cpu_count() or 1)
+        executor = ThreadPoolExecutor(
+            max_workers=max(1, worker_count),
+            thread_name_prefix="wtfs-delete",
+        )
+        try:
+            for directory in directories:
+                try:
+                    target = deletion_path(self.root_path, directory)
+                except (OSError, ValueError) as error:
+                    os_error = error if isinstance(error, OSError) else OSError(str(error))
+                    result = DeletionResult(
+                        self.root_path,
+                        False,
+                        0,
+                        0,
+                        DeletionFailure(
+                            self.root_path,
+                            self.root_path,
+                            "validate target",
+                            os_error,
+                        ),
+                    )
+                    results.append(DirectoryDeletionResult(directory, result))
+                    self.call_from_thread(progress.target_finished, self.root_path)
+                    continue
+
+                future = executor.submit(
+                    delete_tree,
+                    target,
+                    lambda path, count: self.call_from_thread(
+                        progress.advance_entries,
+                        path,
+                        count,
+                    ),
+                )
+                pending[future] = directory
+
+            for future in as_completed(pending):
+                directory = pending[future]
+                try:
+                    result = future.result()
+                except Exception as error:
+                    target = deletion_path(self.root_path, directory)
+                    os_error = OSError(f"unexpected deletion failure: {error}")
+                    result = DeletionResult(
+                        target,
+                        False,
+                        0,
+                        0,
+                        DeletionFailure(
+                            target,
+                            target,
+                            "delete directory",
+                            os_error,
+                        ),
+                    )
+                results.append(DirectoryDeletionResult(directory, result))
+                self.call_from_thread(progress.target_finished, result.target)
+        finally:
+            executor.shutdown(wait=True)
+
+        order = {directory.index: index for index, directory in enumerate(directories)}
+        results.sort(key=lambda item: order[item.directory.index])
+        self.call_from_thread(self._finish_deletion, results, progress)
+
+    def _finish_deletion(
+        self,
+        results: list[DirectoryDeletionResult],
+        progress: DeletionProgress,
+    ) -> None:
+        if self.screen is progress:
+            self.pop_screen()
+
+        deleted = [item.directory for item in results if item.result.deleted]
+        self._remove_completed_directories(deleted)
+
+        if deleted:
+            count = len(deleted)
+            entries = sum(item.result.entries_deleted for item in results)
+            repairs = sum(item.result.permissions_repaired for item in results)
+            repair_note = (
+                f" Repaired permissions on {repairs} entries."
+                if repairs
+                else ""
+            )
+            self.notify(
+                f"Deleted {count} director{'y' if count == 1 else 'ies'} "
+                f"({entries:,} entries).{repair_note}"
+            )
+
+        if any(not item.result.deleted for item in results):
+            self.push_screen(DeletionReport(results))
+
+    def _remove_completed_directories(self, completed: list[Directory]) -> None:
+        """Remove completed directory subtrees from marks and the stale scan view."""
+        completed_indexes = {directory.index for directory in completed}
         for directory in self.data.directories:
             parent_index = directory.index
             seen = set()
             while parent_index not in seen and 0 <= parent_index < len(self.data.directories):
                 seen.add(parent_index)
-                if parent_index in deleted_indexes:
+                if parent_index in completed_indexes:
                     self.marked.discard(directory.index)
                     break
                 parent_index = self.data.directories[parent_index].parent_index
@@ -350,14 +941,163 @@ class WtfsApp(App):
         for node in nodes:
             nodes.extend(node.children)
         for node in nodes:
-            if isinstance(node.data, Directory) and node.data.index in deleted_indexes:
+            if isinstance(node.data, Directory) and node.data.index in completed_indexes:
                 node.remove()
 
-        if deleted:
-            count = len(deleted)
-            self.notify(f"Deleted {count} director{'y' if count == 1 else 'ies'}.")
-        if failures:
-            self.notify("\n".join(failures), severity="error", timeout=10)
+    def _start_archive(
+        self,
+        directories: list[Directory],
+        destination: Path,
+    ) -> None:
+        assert self.root_path is not None
+        for directory in directories:
+            try:
+                source = deletion_path(self.root_path, directory)
+            except (OSError, ValueError) as error:
+                self.notify(str(error), severity="error")
+                return
+            if destination == source or destination.is_relative_to(source):
+                self.notify(
+                    f"Archive destination is inside marked source: {source}",
+                    severity="error",
+                    timeout=10,
+                )
+                return
+
+        progress = ArchiveProgressScreen(directories, destination)
+        self.push_screen(progress)
+        self.call_after_refresh(
+            self._launch_archive_worker,
+            directories,
+            destination,
+            progress,
+        )
+
+    def _launch_archive_worker(
+        self,
+        directories: list[Directory],
+        destination: Path,
+        progress: ArchiveProgressScreen,
+    ) -> None:
+        self.run_worker(
+            lambda: self._archive_in_background(directories, destination, progress),
+            name="archive-marked-directories",
+            group="archive",
+            exclusive=True,
+            thread=True,
+        )
+
+    def _archive_in_background(
+        self,
+        directories: list[Directory],
+        destination: Path,
+        progress: ArchiveProgressScreen,
+    ) -> None:
+        assert self.root_path is not None
+        try:
+            archive_root = create_archive_root(destination)
+        except OSError as error:
+            batch = ArchiveBatchResult(
+                destination,
+                None,
+                [],
+                ArchiveFailure("create archive root", destination, error),
+            )
+            self.call_from_thread(self._finish_archive, batch, progress)
+            return
+
+        self.call_from_thread(progress.set_archive_root, archive_root)
+        results: list[DirectoryArchiveResult] = []
+        pending = {}
+        executor = ThreadPoolExecutor(
+            max_workers=max(1, min(2, len(directories))),
+            thread_name_prefix="wtfs-archive",
+        )
+        try:
+            for directory in directories:
+                source = deletion_path(self.root_path, directory)
+                relative = Path(directory.path or directory.name)
+                item = ArchiveItem(
+                    source,
+                    relative,
+                    directory.total_size,
+                    directory.total_files + directory.total_dirs,
+                )
+                future = executor.submit(
+                    archive_item,
+                    item,
+                    archive_root,
+                    lambda path, byte_count, entry_count: self.call_from_thread(
+                        progress.advance,
+                        path,
+                        byte_count,
+                        entry_count,
+                    ),
+                )
+                pending[future] = directory
+
+            for future in as_completed(pending):
+                directory = pending[future]
+                try:
+                    result = future.result()
+                except Exception as error:
+                    source = deletion_path(self.root_path, directory)
+                    item = ArchiveItem(
+                        source,
+                        Path(directory.path or directory.name),
+                        directory.total_size,
+                        directory.total_files + directory.total_dirs,
+                    )
+                    os_error = OSError(f"unexpected archive failure: {error}")
+                    result = ArchiveResult(
+                        item,
+                        archive_root / item.relative_path,
+                        False,
+                        False,
+                        0,
+                        0,
+                        "none",
+                        ArchiveFailure("archive", source, os_error),
+                    )
+                results.append(DirectoryArchiveResult(directory, result))
+                self.call_from_thread(progress.target_finished, result.item.source)
+        finally:
+            executor.shutdown(wait=True)
+
+        order = {directory.index: index for index, directory in enumerate(directories)}
+        results.sort(key=lambda item: order[item.directory.index])
+        manifest_failure = None
+        try:
+            write_manifest(
+                archive_root,
+                self.root_path,
+                [item.result for item in results],
+            )
+        except OSError as error:
+            manifest_failure = ArchiveFailure(
+                "write manifest",
+                archive_root / "manifest.json",
+                error,
+            )
+
+        batch = ArchiveBatchResult(
+            destination,
+            archive_root,
+            results,
+            manifest_failure,
+        )
+        self.call_from_thread(self._finish_archive, batch, progress)
+
+    def _finish_archive(
+        self,
+        batch: ArchiveBatchResult,
+        progress: ArchiveProgressScreen,
+    ) -> None:
+        if self.screen is progress:
+            self.pop_screen()
+        moved = [item.directory for item in batch.results if item.result.moved]
+        self._remove_completed_directories(moved)
+        self.push_screen(ArchiveReport(batch))
 
 
 def run_interactive(dump_file: str, root_path: str = None) -> None:


### PR DESCRIPTION
## What changed

- add asynchronous marked-directory archiving with a mounted-volume/custom-path chooser
- create unique timestamped archive roots and mirror original relative paths
- use atomic renames on one filesystem and streaming copy-before-delete across volumes
- preserve file metadata and symbolic links and write a JSON archive manifest
- show live byte/file/target progress and durable success or partial-failure reports
- make deletion asynchronous and concurrent, with live progress and conservative permission repair
- retain failed marks for retry and provide exact permission troubleshooting
- add a repository working agreement that commits and pushes completed in-scope work by default

## Safety and failure behavior

Cross-volume sources are removed only after the copy completes. If cleanup fails, the complete archive copy is retained and the source stays marked. Copy failures retain the source and identify any partial destination. Archive destinations inside a marked source are rejected.

## Validation

- 18 Python unit and Textual interaction tests
- `uv run python -m compileall -q wtfs tests`
- `zig fmt --check build.zig src`
- `zig build test`
- `zig build`
- `git diff --check`
- self-cleaning cross-volume smoke test on the connected `/Volumes/Lootbox` mount
